### PR TITLE
Add basic single tenant functionality

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: pdm-project/setup-pdm@v4
         with:
           cache: true
+          cache-dependency-path: pylock.toml
       - run: pdm install --lockfile pylock.toml
 
       - uses: jaxxstorm/action-install-gh-release@v2.1.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: pdm-project/setup-pdm@v4
         with:
           cache: true
-      - run: pdm install
+      - run: pdm install --lockfile pylock.toml
 
       - uses: jaxxstorm/action-install-gh-release@v2.1.0
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: pdm-project/setup-pdm@v4
         with:
           cache: true
+          cache-dependency-path: pylock.toml
       - run: pdm install --lockfile pylock.toml
 
       # test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: pdm-project/setup-pdm@v4
         with:
           cache: true
-      - run: pdm install
+      - run: pdm install --lockfile pylock.toml
 
       # test
       - run: pdm run test

--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
 # httpx-folio
+
+FOLIO related niceties for the [next generation HTTP client](https://www.python-httpx.org/) for Python.
+
+### Not invented here?
+
+There are many existing and excellent FOLIO clients out there for Python.
+* https://github.com/FOLIO-FSE/folioclient
+* https://github.com/balljok/pyfolioclient
+* https://github.com/tobi-weber/foliolib
+
+This library is in no way intended to be a replacement for them.
+Instead it is taking a minimalist approach to configuring a raw HTTPX client for FOLIO with a focus on resilience, stability, and observability.
+If you can use a higher-level client to accomplish your goal you will have a better time using one.
+For all other times httpx-folio is here for you.
+
+As of 0.1.0 it supports
+* [Sync] Okapi and Eureka with a single tenant
+
+Future
+* CQL, sort, and query parameter standardization across endpoints
+* [Async] Okapi and Eureka with a single tenant
+* [(A)Sync] Okapi and Eureka with ECS support
+* [(A)Sync] Edge with a single tenant and ECS support
+
+The hope is that other (existing and new) clients can build on top of this one to avoid re-inventing these wheels.
+
+### The origin
+This code started out in the LDLite repository as it was a little too weird to use the existing python clients.

--- a/pylock.maximal.toml
+++ b/pylock.maximal.toml
@@ -135,6 +135,23 @@ dependencies = [
 ]
 
 [[packages]]
+name = "pytest-asyncio"
+version = "1.1.0"
+requires-python = ">=3.9"
+sdist = {name = "pytest_asyncio-1.1.0.tar.gz", url = "https://files.pythonhosted.org/packages/4e/51/f8794af39eeb870e87a8c8068642fc07bce0c854d6865d7dd0f2a9d338c2/pytest_asyncio-1.1.0.tar.gz", hashes = {sha256 = "796aa822981e01b68c12e4827b8697108f7205020f24b5793b3c41555dab68ea"}}
+wheels = [
+    {name = "pytest_asyncio-1.1.0-py3-none-any.whl",url = "https://files.pythonhosted.org/packages/c7/9d/bf86eddabf8c6c9cb1ea9a869d6873b46f105a5d292d3a6f7071f5b07935/pytest_asyncio-1.1.0-py3-none-any.whl",hashes = {sha256 = "5fe2d69607b0bd75c656d1211f969cadba035030156745ee09e7d71740e58ecf"}},
+]
+marker = "python_version >= \"3.13\" and \"test\" in dependency_groups"
+
+[packages.tool.pdm]
+dependencies = [
+    "backports-asyncio-runner<2,>=1.1; python_version < \"3.11\"",
+    "pytest<9,>=8.2",
+    "typing-extensions>=4.12; python_version < \"3.10\"",
+]
+
+[[packages]]
 name = "pytest-cases"
 version = "3.9.1"
 sdist = {name = "pytest_cases-3.9.1.tar.gz", url = "https://files.pythonhosted.org/packages/c1/69/8b41e074e9e1a9fa85c3765971f213e1b8d4a2f648b457af32dea792bdb8/pytest_cases-3.9.1.tar.gz", hashes = {sha256 = "c4e181f1b525c931a318d4812fa8de656c2c8fb77fccf1571ecf0cc5fe8e7f8f"}}
@@ -471,7 +488,7 @@ dependencies = [
 ]
 
 [tool.pdm]
-hashes = {sha256 = "08f34206884a6d54430fb01566e454bb24502bd10403771f0d487474febfd5d3"}
+hashes = {sha256 = "ec69edba2fc62295d73428fb3c91f6c01da940a68cac60acbb98b1989012e24a"}
 strategy = ["inherit_metadata", "static_urls"]
 
 [[tool.pdm.targets]]

--- a/pylock.minimal.toml
+++ b/pylock.minimal.toml
@@ -201,6 +201,23 @@ dependencies = [
 ]
 
 [[packages]]
+name = "pytest-asyncio"
+version = "1.1.0"
+requires-python = ">=3.9"
+sdist = {name = "pytest_asyncio-1.1.0.tar.gz", url = "https://files.pythonhosted.org/packages/4e/51/f8794af39eeb870e87a8c8068642fc07bce0c854d6865d7dd0f2a9d338c2/pytest_asyncio-1.1.0.tar.gz", hashes = {sha256 = "796aa822981e01b68c12e4827b8697108f7205020f24b5793b3c41555dab68ea"}}
+wheels = [
+    {name = "pytest_asyncio-1.1.0-py3-none-any.whl",url = "https://files.pythonhosted.org/packages/c7/9d/bf86eddabf8c6c9cb1ea9a869d6873b46f105a5d292d3a6f7071f5b07935/pytest_asyncio-1.1.0-py3-none-any.whl",hashes = {sha256 = "5fe2d69607b0bd75c656d1211f969cadba035030156745ee09e7d71740e58ecf"}},
+]
+marker = "\"test\" in dependency_groups"
+
+[packages.tool.pdm]
+dependencies = [
+    "backports-asyncio-runner<2,>=1.1; python_version < \"3.11\"",
+    "pytest<9,>=8.2",
+    "typing-extensions>=4.12; python_version < \"3.10\"",
+]
+
+[[packages]]
 name = "pytest-cases"
 version = "3.9.1"
 sdist = {name = "pytest_cases-3.9.1.tar.gz", url = "https://files.pythonhosted.org/packages/c1/69/8b41e074e9e1a9fa85c3765971f213e1b8d4a2f648b457af32dea792bdb8/pytest_cases-3.9.1.tar.gz", hashes = {sha256 = "c4e181f1b525c931a318d4812fa8de656c2c8fb77fccf1571ecf0cc5fe8e7f8f"}}
@@ -326,6 +343,19 @@ marker = "\"lint\" in dependency_groups and python_version < \"3.11\" or \"test\
 dependencies = []
 
 [[packages]]
+name = "backports-asyncio-runner"
+version = "1.2.0"
+requires-python = "<3.11,>=3.8"
+sdist = {name = "backports_asyncio_runner-1.2.0.tar.gz", url = "https://files.pythonhosted.org/packages/8e/ff/70dca7d7cb1cbc0edb2c6cc0c38b65cba36cccc491eca64cabd5fe7f8670/backports_asyncio_runner-1.2.0.tar.gz", hashes = {sha256 = "a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162"}}
+wheels = [
+    {name = "backports_asyncio_runner-1.2.0-py3-none-any.whl",url = "https://files.pythonhosted.org/packages/a0/59/76ab57e3fe74484f48a53f8e337171b4a2349e506eabe136d7e01d059086/backports_asyncio_runner-1.2.0-py3-none-any.whl",hashes = {sha256 = "0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5"}},
+]
+marker = "python_version < \"3.11\" and \"test\" in dependency_groups"
+
+[packages.tool.pdm]
+dependencies = []
+
+[[packages]]
 name = "httpcore"
 version = "0.13.7"
 requires-python = ">=3.6"
@@ -412,6 +442,19 @@ marker = "\"default\" in dependency_groups"
 dependencies = []
 
 [[packages]]
+name = "typing-extensions"
+version = "4.15.0"
+requires-python = ">=3.9"
+sdist = {name = "typing_extensions-4.15.0.tar.gz", url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hashes = {sha256 = "0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466"}}
+wheels = [
+    {name = "typing_extensions-4.15.0-py3-none-any.whl",url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl",hashes = {sha256 = "f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"}},
+]
+marker = "\"default\" in dependency_groups or \"lint\" in dependency_groups or \"test\" in dependency_groups"
+
+[packages.tool.pdm]
+dependencies = []
+
+[[packages]]
 name = "colorama"
 version = "0.4.6"
 requires-python = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
@@ -438,19 +481,6 @@ marker = "\"default\" in dependency_groups and python_version < \"3.11\" or \"te
 dependencies = [
     "typing-extensions>=4.6.0; python_version < \"3.13\"",
 ]
-
-[[packages]]
-name = "typing-extensions"
-version = "4.15.0"
-requires-python = ">=3.9"
-sdist = {name = "typing_extensions-4.15.0.tar.gz", url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hashes = {sha256 = "0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466"}}
-wheels = [
-    {name = "typing_extensions-4.15.0-py3-none-any.whl",url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl",hashes = {sha256 = "f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"}},
-]
-marker = "\"default\" in dependency_groups or \"lint\" in dependency_groups or \"test\" in dependency_groups"
-
-[packages.tool.pdm]
-dependencies = []
 
 [[packages]]
 name = "idna"
@@ -725,7 +755,7 @@ dependencies = [
 ]
 
 [tool.pdm]
-hashes = {sha256 = "08f34206884a6d54430fb01566e454bb24502bd10403771f0d487474febfd5d3"}
+hashes = {sha256 = "ec69edba2fc62295d73428fb3c91f6c01da940a68cac60acbb98b1989012e24a"}
 strategy = ["direct_minimal_versions", "inherit_metadata", "static_urls"]
 
 [[tool.pdm.targets]]

--- a/pylock.toml
+++ b/pylock.toml
@@ -201,6 +201,23 @@ dependencies = [
 ]
 
 [[packages]]
+name = "pytest-asyncio"
+version = "1.1.0"
+requires-python = ">=3.9"
+sdist = {name = "pytest_asyncio-1.1.0.tar.gz", url = "https://files.pythonhosted.org/packages/4e/51/f8794af39eeb870e87a8c8068642fc07bce0c854d6865d7dd0f2a9d338c2/pytest_asyncio-1.1.0.tar.gz", hashes = {sha256 = "796aa822981e01b68c12e4827b8697108f7205020f24b5793b3c41555dab68ea"}}
+wheels = [
+    {name = "pytest_asyncio-1.1.0-py3-none-any.whl",url = "https://files.pythonhosted.org/packages/c7/9d/bf86eddabf8c6c9cb1ea9a869d6873b46f105a5d292d3a6f7071f5b07935/pytest_asyncio-1.1.0-py3-none-any.whl",hashes = {sha256 = "5fe2d69607b0bd75c656d1211f969cadba035030156745ee09e7d71740e58ecf"}},
+]
+marker = "\"test\" in dependency_groups"
+
+[packages.tool.pdm]
+dependencies = [
+    "backports-asyncio-runner<2,>=1.1; python_version < \"3.11\"",
+    "pytest<9,>=8.2",
+    "typing-extensions>=4.12; python_version < \"3.10\"",
+]
+
+[[packages]]
 name = "pytest-cases"
 version = "3.9.1"
 sdist = {name = "pytest_cases-3.9.1.tar.gz", url = "https://files.pythonhosted.org/packages/c1/69/8b41e074e9e1a9fa85c3765971f213e1b8d4a2f648b457af32dea792bdb8/pytest_cases-3.9.1.tar.gz", hashes = {sha256 = "c4e181f1b525c931a318d4812fa8de656c2c8fb77fccf1571ecf0cc5fe8e7f8f"}}
@@ -340,6 +357,19 @@ marker = "\"lint\" in dependency_groups and python_version < \"3.11\" or \"test\
 dependencies = []
 
 [[packages]]
+name = "backports-asyncio-runner"
+version = "1.2.0"
+requires-python = "<3.11,>=3.8"
+sdist = {name = "backports_asyncio_runner-1.2.0.tar.gz", url = "https://files.pythonhosted.org/packages/8e/ff/70dca7d7cb1cbc0edb2c6cc0c38b65cba36cccc491eca64cabd5fe7f8670/backports_asyncio_runner-1.2.0.tar.gz", hashes = {sha256 = "a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162"}}
+wheels = [
+    {name = "backports_asyncio_runner-1.2.0-py3-none-any.whl",url = "https://files.pythonhosted.org/packages/a0/59/76ab57e3fe74484f48a53f8e337171b4a2349e506eabe136d7e01d059086/backports_asyncio_runner-1.2.0-py3-none-any.whl",hashes = {sha256 = "0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5"}},
+]
+marker = "python_version < \"3.11\" and \"test\" in dependency_groups"
+
+[packages.tool.pdm]
+dependencies = []
+
+[[packages]]
 name = "pluggy"
 version = "1.6.0"
 requires-python = ">=3.9"
@@ -348,6 +378,19 @@ wheels = [
     {name = "pluggy-1.6.0-py3-none-any.whl",url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl",hashes = {sha256 = "e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746"}},
 ]
 marker = "\"test\" in dependency_groups"
+
+[packages.tool.pdm]
+dependencies = []
+
+[[packages]]
+name = "typing-extensions"
+version = "4.15.0"
+requires-python = ">=3.9"
+sdist = {name = "typing_extensions-4.15.0.tar.gz", url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hashes = {sha256 = "0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466"}}
+wheels = [
+    {name = "typing_extensions-4.15.0-py3-none-any.whl",url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl",hashes = {sha256 = "f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"}},
+]
+marker = "\"default\" in dependency_groups or \"lint\" in dependency_groups or \"test\" in dependency_groups"
 
 [packages.tool.pdm]
 dependencies = []
@@ -379,19 +422,6 @@ marker = "\"default\" in dependency_groups and python_version < \"3.11\" or \"te
 dependencies = [
     "typing-extensions>=4.6.0; python_version < \"3.13\"",
 ]
-
-[[packages]]
-name = "typing-extensions"
-version = "4.15.0"
-requires-python = ">=3.9"
-sdist = {name = "typing_extensions-4.15.0.tar.gz", url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hashes = {sha256 = "0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466"}}
-wheels = [
-    {name = "typing_extensions-4.15.0-py3-none-any.whl",url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl",hashes = {sha256 = "f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"}},
-]
-marker = "\"default\" in dependency_groups or \"lint\" in dependency_groups or \"test\" in dependency_groups"
-
-[packages.tool.pdm]
-dependencies = []
 
 [[packages]]
 name = "h11"
@@ -631,7 +661,7 @@ dependencies = [
 ]
 
 [tool.pdm]
-hashes = {sha256 = "08f34206884a6d54430fb01566e454bb24502bd10403771f0d487474febfd5d3"}
+hashes = {sha256 = "ec69edba2fc62295d73428fb3c91f6c01da940a68cac60acbb98b1989012e24a"}
 strategy = ["inherit_metadata", "static_urls"]
 
 [[tool.pdm.targets]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ package-dir = "src"
 [tool.pytest.ini_options]
 pythonpath = "src"
 addopts = ["--import-mode=importlib"]
+asyncio_mode = "auto"
 
 [tool.coverage.run]
 branch = true
@@ -63,4 +64,5 @@ test = [
     "pytest==8.4.1",
     "pytest-cases==3.9.1",
     "coverage==7.10.5",
+    "pytest-asyncio==1.1.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ pydocstyle.convention = "google"
 mypy-init-return = true
 
 [tool.pdm.scripts]
+test-quick = "python -m pytest -vv -k 'not Integration' {args}"
 test.composite = ["rm -f .coverage", "python -m coverage run -m pytest -vv {args}", "python -m coverage report"]
 lock.composite = ["rm -f pylock.toml", "pdm lock --python=3.9", "pdm lock --lockfile pylock.maximal.toml --python=3.13", "pdm lock --strategy direct_minimal_versions --lockfile pylock.minimal.toml --python=3.9"]
 test-install.composite = ["pdm sync --lockfile=pylock.minimal.toml", "pdm sync --lockfile=pylock.toml"]

--- a/src/httpx_folio/auth.py
+++ b/src/httpx_folio/auth.py
@@ -1,0 +1,87 @@
+"""FOLIO Authentication Schemes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from http import HTTPStatus
+from typing import TYPE_CHECKING, NamedTuple
+
+import httpx
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator, Generator
+
+
+@dataclass(frozen=True)
+class FolioParams:
+    """Connection parameters for FOLIO.
+
+    base_url and auth_tenant can be found in Settings > Software versions.
+    """
+
+    """The service url for FOLIO."""
+    base_url: str
+    """The FOLIO tenant used for authentication.
+
+    ECS setups are not currently supported, but the name auth_tenant has been
+    chosen for future compatibility with ECS."""
+    auth_tenant: str
+    """The service user with permissions to query FOLIO."""
+    username: str
+    """The service user's FOLIO password."""
+    password: str
+
+
+class RefreshTokenAuth(httpx.Auth):
+    """Implements FOLIO's refresh token auth scheme.
+
+    Eureka and Okapi backends are supported by this scheme.
+    """
+
+    class _Token(NamedTuple):
+        value: str
+
+    def __init__(self, params: FolioParams):
+        """Initializes the Authentication method with an access token."""
+        self._params = params
+        self._token = RefreshTokenAuth._do_auth(self._params)
+
+    def auth_flow(
+        self,
+        request: httpx.Request,
+    ) -> Generator[httpx.Request, httpx.Response, None]:
+        """Override the default auth_flow to manage FOLIO token headers and refresh."""
+        t = self._token.value
+        request.headers["x-okapi-token"] = t
+        response = yield request
+
+        if response.status_code == HTTPStatus.UNAUTHORIZED:
+            self._token = RefreshTokenAuth._do_auth(self._params)
+            t = self._token.value
+            request.headers["x-okapi-token"] = t
+            yield request
+
+    async def async_auth_flow(
+        self,
+        request: httpx.Request,
+    ) -> AsyncGenerator[httpx.Request, httpx.Response]:
+        """Override the default async_auth_flow to block unsupported usage."""
+        sync_msg = "Cannot use a sync authentication class with httpx.AsyncClient"
+        raise RuntimeError(sync_msg)
+        yield request  # Unreachable but makes type checking happier
+
+    @staticmethod
+    def _do_auth(params: FolioParams) -> RefreshTokenAuth._Token:
+        res = httpx.post(
+            params.base_url.rstrip("/") + "/authn/login-with-expiry",
+            headers={"x-okapi-tenant": params.auth_tenant},
+            json={
+                "username": params.username,
+                "password": params.password,
+            },
+        )
+        res.raise_for_status()
+
+        return RefreshTokenAuth._Token(
+            res.cookies["folioAccessToken"],
+        )

--- a/src/httpx_folio/factories.py
+++ b/src/httpx_folio/factories.py
@@ -1,0 +1,61 @@
+"""Factories for httpx clients configured for FOLIO."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Callable
+
+import httpx
+from httpx_retries import Retry, RetryTransport
+
+from .auth import FolioParams, RefreshTokenAuth
+
+
+def _httpx_default_timeout() -> httpx._types.TimeoutTypes:
+    return httpx.Timeout(timeout=5.0)
+
+
+@dataclass(frozen=True)
+class BasicClientOptions:
+    """The most basic options for creating FOLIO client."""
+
+    retries: int = 3
+    timeout: httpx._types.TimeoutTypes = field(default_factory=_httpx_default_timeout)
+
+
+def default_client_factory(
+    params: FolioParams,
+) -> Callable[[BasicClientOptions | None], httpx.Client]:
+    """Factory method for creating a single tenant client with no customizations.
+
+    Returns:
+        A factory method for creating basic httpx Clients connected to FOLIO.
+
+    Raises:
+        httpx.HTTPError: When the provided params do not connect to FOLIO.
+
+    Examples:
+        from httpx_folio.auth import FolioParams
+        from httpx_folio.factories import make_client_factory
+
+        client_factory = make_client_factory(FolioParams(
+            'https://folio-etesting-snapshot-kong.ci.folio.org',
+            'diku',
+            'diku_admin',
+            'admin',
+        ))
+        with client_factory() as client:
+            res = client.get(...)
+            ...
+
+    """
+    auth = RefreshTokenAuth(params)
+    return lambda o: httpx.Client(
+        auth=auth,
+        base_url=params.base_url,
+        transport=RetryTransport(
+            retry=Retry(total=(o or BasicClientOptions()).retries, backoff_factor=0.5),
+        ),
+        timeout=(o or BasicClientOptions()).timeout,
+        headers={"x-okapi-tenant": params.auth_tenant},
+    )

--- a/tests/test_factories/test_default.py
+++ b/tests/test_factories/test_default.py
@@ -1,0 +1,19 @@
+class TestIntegration:
+    def test_ok(self) -> None:
+        from httpx_folio.factories import FolioParams
+        from httpx_folio.factories import (
+            default_client_factory as make_client_factory,
+        )
+
+        uut = make_client_factory(
+            FolioParams(
+                "https://folio-etesting-snapshot-kong.ci.folio.org",
+                "diku",
+                "diku_admin",
+                "admin",
+            ),
+        )
+        with uut() as client:
+            res = client.get("/groups")
+            res.raise_for_status()
+            assert res.json()["totalRecords"] > 0

--- a/tests/test_refreshtokenauth.py
+++ b/tests/test_refreshtokenauth.py
@@ -1,0 +1,73 @@
+from dataclasses import dataclass
+
+import httpx
+import pytest
+from pytest_cases import parametrize_with_cases
+
+
+class TestIntegration:
+    def test_ok(self) -> None:
+        from httpx_folio.auth import FolioParams
+        from httpx_folio.auth import RefreshTokenAuth as uut
+
+        uut(
+            FolioParams(
+                "https://folio-etesting-snapshot-kong.ci.folio.org",
+                "diku",
+                "diku_admin",
+                "admin",
+            ),
+        )
+
+    @dataclass(frozen=True)
+    class FolioConnectionCase:
+        expected: type[Exception]
+        index: int
+        value: str
+
+    class FolioConnectionCases:
+        def case_url(self) -> "TestIntegration.FolioConnectionCase":
+            return TestIntegration.FolioConnectionCase(
+                expected=httpx.ConnectError,
+                index=0,
+                value="https://not.folio.fivecolleges.edu",
+            )
+
+        def case_tenant(self) -> "TestIntegration.FolioConnectionCase":
+            return TestIntegration.FolioConnectionCase(
+                expected=httpx.HTTPStatusError,
+                index=1,
+                value="not a tenant",
+            )
+
+        def case_user(self) -> "TestIntegration.FolioConnectionCase":
+            return TestIntegration.FolioConnectionCase(
+                expected=httpx.HTTPStatusError,
+                index=2,
+                value="not a user",
+            )
+
+        def case_password(self) -> "TestIntegration.FolioConnectionCase":
+            return TestIntegration.FolioConnectionCase(
+                expected=httpx.HTTPStatusError,
+                index=3,
+                value="not the password",
+            )
+
+    @parametrize_with_cases("tc", cases=FolioConnectionCases)
+    def test_bad_folio_connection(
+        self,
+        tc: FolioConnectionCase,
+    ) -> None:
+        from httpx_folio.auth import FolioParams
+        from httpx_folio.auth import RefreshTokenAuth as uut
+
+        params = [
+            "https://folio-etesting-snapshot-kong.ci.folio.org",
+            "diku",
+            "diku_admin",
+            "admin",
+        ]
+        params = [*params[: tc.index], tc.value, *params[tc.index + 1 :]]
+        with pytest.raises(tc.expected):
+            uut(FolioParams(*params))


### PR DESCRIPTION
This takes a some of the code that was written for LDLite to implement retries and token refresh natively in HTTPX and makes it available to other libraries. The tests are here as well because they're not really that related to LDLite.