### PR TITLE
Add QueryParams normalization and generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,31 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+Please see [MIGRATING.md](./MIGRATING.md) for information on breaking changes.
+
+## [Unreleased]
+
+### Added
+
+### Fixed
+
+### Changed
+
+### Removed
+
+## [0.2.0] - September 2025
+
+### Added
+- HTTPX QueryParameter standardization and generation for common FOLIO scenarios.
+
+## [0.1.0] - August 2025
+
+The initial release.
+
+### Added
+- A resilient HTTPX Client factory for synchronous single tenant FOLIO instances.
+- A custom synchronous HTTPX Authentication scheme for FOLIO Refresh Token Auth.

--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ Instead it is taking a minimalist approach to configuring a raw HTTPX client for
 If you can use a higher-level client to accomplish your goal you will have a better time using one.
 For all other times httpx-folio is here for you.
 
-As of 0.1.0 it supports
+As of 0.2.0 it supports
 * [Sync] Okapi and Eureka with a single tenant
+* Query and paging parameter handling
 
 Future
-* CQL, sort, and query parameter standardization across endpoints
 * [Async] Okapi and Eureka with a single tenant
 * [(A)Sync] Okapi and Eureka with ECS support
 * [(A)Sync] Edge with a single tenant and ECS support

--- a/pylock.maximal.toml
+++ b/pylock.maximal.toml
@@ -218,11 +218,11 @@ dependencies = [
 
 [[packages]]
 name = "httpx-retries"
-version = "0.4.1"
+version = "0.4.2"
 requires-python = ">=3.9"
-sdist = {name = "httpx_retries-0.4.1.tar.gz", url = "https://files.pythonhosted.org/packages/2a/cd/4aabdb837943ab1e890cd6104f84d35a94ae4ae0efb684d95792a1f16f45/httpx_retries-0.4.1.tar.gz", hashes = {sha256 = "008c10a57ee73665fa82bfa28466c736da5214b31ee6eacec8707c36493ed152"}}
+sdist = {name = "httpx_retries-0.4.2.tar.gz", url = "https://files.pythonhosted.org/packages/9e/32/37cd73ca29912cc572cec2a79b09cb719786d22e37bf02140bc750d34b36/httpx_retries-0.4.2.tar.gz", hashes = {sha256 = "8c32b781cf18dc9d67fc380792bf465cde107831ec1c1c504a7df6c80f06536c"}}
 wheels = [
-    {name = "httpx_retries-0.4.1-py3-none-any.whl",url = "https://files.pythonhosted.org/packages/40/72/a580f4ecfa22f59b7c3ecd551174cf46c78f4633c687d08eafeacb445144/httpx_retries-0.4.1-py3-none-any.whl",hashes = {sha256 = "756020a4d67eccea5785b30a27c0df413bda5f718b5e5847fa163b51e3348144"}},
+    {name = "httpx_retries-0.4.2-py3-none-any.whl",url = "https://files.pythonhosted.org/packages/a4/73/0700c81ad08787e2648de8ae69c046bdfee865216187bdd43cb2ba35b36c/httpx_retries-0.4.2-py3-none-any.whl",hashes = {sha256 = "0393e2ee1ab7a90aa748733cc8fe8ff722f21f282fc8f8780369089918cec994"}},
 ]
 marker = "python_version >= \"3.13\" and \"default\" in dependency_groups"
 

--- a/pylock.toml
+++ b/pylock.toml
@@ -284,11 +284,11 @@ dependencies = [
 
 [[packages]]
 name = "httpx-retries"
-version = "0.4.1"
+version = "0.4.2"
 requires-python = ">=3.9"
-sdist = {name = "httpx_retries-0.4.1.tar.gz", url = "https://files.pythonhosted.org/packages/2a/cd/4aabdb837943ab1e890cd6104f84d35a94ae4ae0efb684d95792a1f16f45/httpx_retries-0.4.1.tar.gz", hashes = {sha256 = "008c10a57ee73665fa82bfa28466c736da5214b31ee6eacec8707c36493ed152"}}
+sdist = {name = "httpx_retries-0.4.2.tar.gz", url = "https://files.pythonhosted.org/packages/9e/32/37cd73ca29912cc572cec2a79b09cb719786d22e37bf02140bc750d34b36/httpx_retries-0.4.2.tar.gz", hashes = {sha256 = "8c32b781cf18dc9d67fc380792bf465cde107831ec1c1c504a7df6c80f06536c"}}
 wheels = [
-    {name = "httpx_retries-0.4.1-py3-none-any.whl",url = "https://files.pythonhosted.org/packages/40/72/a580f4ecfa22f59b7c3ecd551174cf46c78f4633c687d08eafeacb445144/httpx_retries-0.4.1-py3-none-any.whl",hashes = {sha256 = "756020a4d67eccea5785b30a27c0df413bda5f718b5e5847fa163b51e3348144"}},
+    {name = "httpx_retries-0.4.2-py3-none-any.whl",url = "https://files.pythonhosted.org/packages/a4/73/0700c81ad08787e2648de8ae69c046bdfee865216187bdd43cb2ba35b36c/httpx_retries-0.4.2-py3-none-any.whl",hashes = {sha256 = "0393e2ee1ab7a90aa748733cc8fe8ff722f21f282fc8f8780369089918cec994"}},
 ]
 marker = "\"default\" in dependency_groups"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "httpx-folio"
-version = "0.1.0"
+version = "0.2.0"
 description = "FOLIO related niceties for the next generation HTTP client for Python"
 authors = [
     {name = "Katherine Bargar", email = "kbargar@fivecolleges.edu"},

--- a/src/httpx_folio/query.py
+++ b/src/httpx_folio/query.py
@@ -242,9 +242,15 @@ class QueryParams:
             params = params.add("sort", "id;asc")
 
         if self._is_erm is None and self._limit > ERM_MAX_PERPAGE:
-            # ERM supports a max perPage of 100
-            # having a limit over 100 can not be normalized for offset paging
+            # page size can't be normalized if it is over 100
             params = params.remove("sort")
             params = params.remove("perPage")
 
-        return params.set("offset", (page or 0) * self._limit)
+        limit = self._limit
+        if self._is_erm:
+            # ERM has a max page size of 100
+            # if we know we're paging ERM then we'll override the provided page size
+            limit = min(limit, ERM_MAX_PERPAGE)
+            params = params.set("perPage", limit)
+
+        return params.set("offset", (page or 0) * limit)

--- a/src/httpx_folio/query.py
+++ b/src/httpx_folio/query.py
@@ -1,11 +1,11 @@
-"""A compatibility layer over FOLIO query parameters."""
+"""A compatibility layer over FOLIO query parameters with common paging scenarios."""
 
 from __future__ import annotations
 
 import re
 from collections.abc import Sequence
 from enum import IntEnum
-from typing import Union, cast
+from typing import Annotated, Union, cast
 
 import httpx
 
@@ -13,17 +13,239 @@ DEFAULT_PAGE_SIZE = 100
 ERM_MAX_PERPAGE = 100
 CQL_ALL_RECORDS = "cql.allRecords=1"
 
-QueryType = Union[
-    str,
-    httpx.QueryParams,
-    dict[
+QueryType = Annotated[
+    Union[
         str,
-        Union[
-            Union[str, int, float, bool],
-            Sequence[Union[str, int, float, bool]],
+        httpx.QueryParams,
+        dict[
+            str,
+            Union[
+                Union[str, int, float, bool],
+                Sequence[Union[str, int, float, bool]],
+            ],
         ],
     ],
+    "A simplified version of HTTPX's QueryParamTypes.",
 ]
+
+
+class QueryParams:
+    """An container for generating HTTPX QueryParams with FOLIO quirks."""
+
+    def __init__(
+        self,
+        query: QueryType | None,
+        limit: int = DEFAULT_PAGE_SIZE,
+    ):
+        """Initializes a base set of query parameters to generate variations.
+
+        Raises:
+            TypeError: If the query or filter string is not parseable.
+            ValueError: If the query or filter key is not parseable.
+        """
+        self._limit = limit
+
+        self._query: list[str] = []
+        self._base_query: str | None = None
+        self._is_erm: bool | None = None
+        self._is_cql: bool | None = None
+        self._sort_type = _SortType.UNSORTED
+
+        if query is None:
+            self._additional_params = httpx.QueryParams()
+            return
+
+        parser = _QueryParser(query)
+        self._additional_params = parser.additional_params()
+
+        (q, qc, is_cql) = parser.check_string()
+        if q is not None:
+            self._query = [q]
+        if qc is not None:
+            self._base_query = qc
+        if is_cql:
+            self._is_erm = False
+            self._is_cql = True
+
+        # Queries and filters could be hiding
+        (q, qc, is_cql) = parser.check_query()
+        if q is not None:
+            self._query = [q]
+        if qc is not None:
+            self._base_query = qc
+        if is_cql:
+            self._is_erm = False
+            self._is_cql = True
+
+        filters = parser.check_filters()
+        if filters is not None:
+            self._query = filters
+            self._is_erm = True
+            self._is_cql = False
+
+        if parser.check_erm():
+            self._is_erm = True
+            self._is_cql = False
+
+        self._sort_type = parser.check_sort()
+
+    def normalized(self) -> httpx.QueryParams:
+        """Parameters compatible with all FOLIO endpoints.
+
+        Different endpoints have different practices for sorting and filtering.
+        The biggest change is between ERM and non-ERM. This will duplicate the
+        parameters to work across both (and more as they're discovered).
+
+        This also normalizes the return values of ERM endpoints which by default
+        to not return stats making them a different shape than other endpoints.
+        """
+        params = self._additional_params
+        # add cql params if it is or might be cql
+        if self._is_cql is None or self._is_cql:
+            params = params.merge(
+                {
+                    # CQL endpoints use query,
+                    # only some are ok without cql.allRecords but they're all ok with it
+                    "query": self._query[0]
+                    if len(self._query) == 1
+                    else CQL_ALL_RECORDS,
+                    "limit": self._limit,
+                },
+            )
+
+        # add erm params if it is or might be erm
+        if self._is_erm is None or self._is_erm:
+            # ERM uses the filters property, it is fine without a cql.allRecords
+            for q in self._query:
+                params = params.add("filters", q)
+            params = params.merge(
+                {
+                    "perPage": self._limit,
+                    # ERM doesn't return the allRecords count unless stats is passed
+                    "stats": True,
+                },
+            )
+        return params
+
+    def stats(self) -> httpx.QueryParams:
+        """Parameters for a single record to get the shape and totalRecord count.
+
+        Zero or One records will be returned regardless of the current limit.
+        """
+        params = self.normalized()
+        # add a sort so null records go to the end
+        if "query" in params and self._sort_type == _SortType.UNSORTED:
+            params = params.set("query", params["query"] + " sortBy id")
+        if ("sort" not in params) and (self._is_erm is None or self._is_erm):
+            params = params.add("sort", "id;asc")
+
+        # override the limit
+        if "limit" in params:
+            params = params.set("limit", 1)
+        if "perPage" in params:
+            params = params.set("perPage", 1)
+
+        return params
+
+    def offset_paging(self, page: int = 1) -> httpx.QueryParams:
+        """Parameters for a single one-based page of results.
+
+        Paging by offset has performance issues for large offsets.
+        If possible use id_paging instead.
+
+        ERM has a hard maximum limit of 100 results which impacts this paging.
+        If the current parameter set is known to be ERM then each page
+        will have at most 100 records even if the limit was set higher.
+        If the current parameter set is ambigous ERM paging parameters will be
+        omitted if the limit is set over 100 to avoid missing data.
+        """
+        params = self.normalized()
+        # add a sort so results are pageable
+        if "query" in params and self._sort_type == _SortType.UNSORTED:
+            params = params.set("query", params["query"] + " sortBy id")
+
+        if ("sort" not in params) and (self._is_erm is None or self._is_erm):
+            params = params.add("sort", "id;asc")
+
+        if self._is_erm is None and self._limit > ERM_MAX_PERPAGE:
+            # page size can't be normalized if it is over 100
+            params = params.remove("stats")
+            params = params.remove("sort")
+            params = params.remove("perPage")
+
+        limit = self._limit
+        if self._is_erm:
+            # ERM has a max page size of 100
+            # if we know we're paging ERM then we'll override the provided page size
+            limit = min(limit, ERM_MAX_PERPAGE)
+            params = params.set("perPage", limit)
+
+        return params.set("offset", (page - 1) * limit)
+
+    def can_page_by_id(self) -> bool:
+        """Indicates whether the current set of parameters supports id_paging."""
+        return self._sort_type != _SortType.NONSTANDARD
+
+    def id_paging(self, last_id: str | None = None) -> httpx.QueryParams:
+        """Parameters for a single page of results.
+
+        Paging by id is not supported for queries sorted on non-id fields. Use
+        offset_paging instead, can_page_by_id() will tell you if id paging is supported.
+
+        Paging by id is not supported for endpoints that do not have id fields. Use
+        stats() to determine whether the records contain id fields. Calling
+        id_paging() in this scenario will appear to succeed
+        but may have missing or duplicated results.
+
+        Raises:
+            RuntimeError: If can_page_by_id() is False
+        """
+        if not self.can_page_by_id():
+            msg = (
+                "Id Paging is not supported in the current parameter configuration."
+                "Use Offset Paging instead."
+            )
+            raise RuntimeError(msg)
+
+        params = self.normalized()
+
+        last_id = last_id or (
+            "99999999-9999-9999-9999-999999999999"
+            if self._sort_type == _SortType.DESCENDING
+            else "00000000-0000-0000-0000-000000000000"
+        )
+
+        if self._is_cql is None or self._is_cql:
+            q = (
+                f"id<{last_id}"
+                if self._sort_type == _SortType.DESCENDING
+                else f"id>{last_id}"
+            )
+            if self._base_query is not None:
+                q += f" and ({self._base_query})"
+            elif len(self._query) == 1:
+                q += f" and ({self._query[0]})"
+
+            params = params.set(
+                "query",
+                f"{q} sortBy id/sort.descending"
+                if self._sort_type == _SortType.DESCENDING
+                else f"{q} sortBy id",
+            )
+
+        if self._is_erm is None or self._is_erm:
+            params = params.set(
+                "sort",
+                "id;desc" if self._sort_type == _SortType.DESCENDING else "id;asc",
+            )
+            params = params.add(
+                "filters",
+                f"id<{last_id}"
+                if self._sort_type == _SortType.DESCENDING
+                else f"id>{last_id}",
+            )
+
+        return params
 
 
 class _SortType(IntEnum):
@@ -110,7 +332,7 @@ class _QueryParser:
             return filters
 
         msg = f"Unexpected value {self.query['filters']} for filter parameter."
-        raise TypeError(msg)
+        raise ValueError(msg)
 
     def check_erm(self) -> bool:
         return (
@@ -173,207 +395,3 @@ class _QueryParser:
             for r in self._reserved:
                 query = query.remove(r)
         return query
-
-
-class QueryParams:
-    """An container for generating query parameters."""
-
-    _cql_re = re.compile(r"^.*sortby.*$", re.IGNORECASE)
-
-    def __init__(
-        self,
-        query: QueryType | None,
-        limit: int = DEFAULT_PAGE_SIZE,
-    ):
-        """Initializes a base set of query parameters to generate variations."""
-        self._limit = limit
-
-        self._query: list[str] = []
-        self._base_query: str | None = None
-        self._is_erm: bool | None = None
-        self._is_cql: bool | None = None
-        self._sort_type = _SortType.UNSORTED
-
-        if query is None:
-            self._additional_params = httpx.QueryParams()
-            return
-
-        parser = _QueryParser(query)
-        self._additional_params = parser.additional_params()
-
-        (q, qc, is_cql) = parser.check_string()
-        if q is not None:
-            self._query = [q]
-        if qc is not None:
-            self._base_query = qc
-        if is_cql:
-            self._is_erm = False
-            self._is_cql = True
-
-        # Queries and filters could be hiding
-        (q, qc, is_cql) = parser.check_query()
-        if q is not None:
-            self._query = [q]
-        if qc is not None:
-            self._base_query = qc
-        if is_cql:
-            self._is_erm = False
-            self._is_cql = True
-
-        filters = parser.check_filters()
-        if filters is not None:
-            self._query = filters
-            self._is_erm = True
-            self._is_cql = False
-
-        if parser.check_erm():
-            self._is_erm = True
-            self._is_cql = False
-
-        self._sort_type = parser.check_sort()
-
-    def normalized(self) -> httpx.QueryParams:
-        """Parameters compatible with all FOLIO endpoints.
-
-        Different endpoints have different practices for sorting and filtering.
-        The biggest change is between ERM and non-ERM. This will duplicate the
-        parameters to work across both (and more as they're discovered).
-
-        This also normalizes the return values of the ERM endpoints which by default
-        to not return stats making them a different shape than other endpoints.
-        """
-        params = self._additional_params
-        # add cql params if it is or might be cql
-        if self._is_cql is None or self._is_cql:
-            params = params.merge(
-                {
-                    # CQL endpoints use query,
-                    # only some are ok without cql.allRecords but they're all ok with it
-                    "query": self._query[0]
-                    if len(self._query) == 1
-                    else CQL_ALL_RECORDS,
-                    "limit": self._limit,
-                },
-            )
-
-        # add erm params if it is or might be erm
-        if self._is_erm is None or self._is_erm:
-            # ERM uses the filters property, it is fine without a cql.allRecords
-            for q in self._query:
-                params = params.add("filters", q)
-            params = params.merge(
-                {
-                    "perPage": self._limit,
-                    # ERM doesn't return the allRecords count unless stats is passed
-                    "stats": True,
-                },
-            )
-        return params
-
-    def stats(self) -> httpx.QueryParams:
-        """Parameters for a single row to get the shape and totalRecord count.
-
-        Zero or One records will be returned regardless of the endpoint's
-        sorting/filtering practices.
-        """
-        params = self.normalized()
-        # add a sort so null records go to the end
-        if "query" in params and self._sort_type == _SortType.UNSORTED:
-            params = params.set("query", params["query"] + " sortBy id")
-        if ("sort" not in params) and (self._is_erm is None or self._is_erm):
-            params = params.add("sort", "id;asc")
-
-        # override the limit
-        if "limit" in params:
-            params = params.set("limit", 1)
-        if "perPage" in params:
-            params = params.set("perPage", 1)
-
-        return params
-
-    def offset_paging(self, page: int = 1) -> httpx.QueryParams:
-        """Parameters for a single page of results.
-
-        Paging by offset has performance issues for large offsets.
-        If possible use id_paging instead.
-        """
-        params = self.normalized()
-        # add a sort so results are pageable
-        if "query" in params and self._sort_type == _SortType.UNSORTED:
-            params = params.set("query", params["query"] + " sortBy id")
-
-        if ("sort" not in params) and (self._is_erm is None or self._is_erm):
-            params = params.add("sort", "id;asc")
-
-        if self._is_erm is None and self._limit > ERM_MAX_PERPAGE:
-            # page size can't be normalized if it is over 100
-            params = params.remove("stats")
-            params = params.remove("sort")
-            params = params.remove("perPage")
-
-        limit = self._limit
-        if self._is_erm:
-            # ERM has a max page size of 100
-            # if we know we're paging ERM then we'll override the provided page size
-            limit = min(limit, ERM_MAX_PERPAGE)
-            params = params.set("perPage", limit)
-
-        return params.set("offset", (page - 1) * limit)
-
-    def can_page_by_id(self) -> bool:
-        """Indicates whether the current set of parameters supports id_paging."""
-        return self._sort_type != _SortType.NONSTANDARD
-
-    def id_paging(self, last_id: str | None = None) -> httpx.QueryParams:
-        """Parameters for a single page of results.
-
-        Paging by id is not supported for queries sorted on non-id columns
-        or for endpoints that do not have an id.
-        Use offset_paging instead.
-        """
-        if not self.can_page_by_id():
-            msg = (
-                "Id Paging is not supported in the current parameter configuration."
-                "Use Offset Paging instead."
-            )
-            raise RuntimeError(msg)
-
-        params = self.normalized()
-
-        last_id = last_id or (
-            "99999999-9999-9999-9999-999999999999"
-            if self._sort_type == _SortType.DESCENDING
-            else "00000000-0000-0000-0000-000000000000"
-        )
-
-        if self._is_cql is None or self._is_cql:
-            q = (
-                f"id<{last_id}"
-                if self._sort_type == _SortType.DESCENDING
-                else f"id>{last_id}"
-            )
-            if self._base_query is not None:
-                q += f" and ({self._base_query})"
-            elif len(self._query) == 1:
-                q += f" and ({self._query[0]})"
-
-            params = params.set(
-                "query",
-                f"{q} sortBy id/sort.descending"
-                if self._sort_type == _SortType.DESCENDING
-                else f"{q} sortBy id",
-            )
-
-        if self._is_erm is None or self._is_erm:
-            params = params.set(
-                "sort",
-                "id;desc" if self._sort_type == _SortType.DESCENDING else "id;asc",
-            )
-            params = params.add(
-                "filters",
-                f"id<{last_id}"
-                if self._sort_type == _SortType.DESCENDING
-                else f"id>{last_id}",
-            )
-
-        return params

--- a/src/httpx_folio/query.py
+++ b/src/httpx_folio/query.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import re
+
 import httpx
 
 DEFAULT_PAGE_SIZE = 100
@@ -9,6 +11,8 @@ DEFAULT_PAGE_SIZE = 100
 
 class QueryParams:
     """An container for generating query parameters."""
+
+    _cql_re = re.compile(r"^.*sortby.*$", re.IGNORECASE)
 
     def __init__(
         self,
@@ -18,6 +22,13 @@ class QueryParams:
         """Initializes a base set of query parameters to generate variations."""
         self._query = query
         self._limit = limit
+
+        self._is_erm: bool | None = None
+        self._is_cql: bool | None = None
+
+        if query is not None and self._cql_re.match(query):
+            self._is_erm = False
+            self._is_cql = True
 
     def normalized(self) -> httpx.QueryParams:
         """Parameters compatible with all FOLIO endpoints.
@@ -29,19 +40,30 @@ class QueryParams:
         This also normalizes the return values of the ERM endpoints which by default
         to not return stats making them a different shape than other endpoints.
         """
-        params = httpx.QueryParams(
-            {
-                # Most endpoints use query,
-                # only some are ok without cql.allRecords they're all ok with it
-                "query": self._query if self._query is not None else "cql.allRecords=1",
-                # limit and perPage seem to be the only parameters limiting results
-                "limit": self._limit,
-                "perPage": self._limit,
-                # ERM doesn't return the allRecords count unless stats is passed
-                "stats": True,
-            },
-        )
-        if self._query is not None:
-            # ERM uses the filters property, it is fine without a cql.allRecords
-            params = params.add("filters", self._query)
+        params = httpx.QueryParams()
+        # add cql params if it is or might be cql
+        if self._is_cql is None or self._is_cql:
+            params = params.merge(
+                {
+                    # Most endpoints use query,
+                    # only some are ok without cql.allRecords but they're all ok with it
+                    "query": self._query
+                    if self._query is not None
+                    else "cql.allRecords=1",
+                    "limit": self._limit,
+                },
+            )
+
+        # add erm params if it is or might be erm
+        if self._is_erm is None or self._is_erm:
+            if self._query is not None:
+                # ERM uses the filters property, it is fine without a cql.allRecords
+                params = params.add("filters", self._query)
+            params = params.merge(
+                {
+                    "perPage": self._limit,
+                    # ERM doesn't return the allRecords count unless stats is passed
+                    "stats": True,
+                },
+            )
         return params

--- a/src/httpx_folio/query.py
+++ b/src/httpx_folio/query.py
@@ -211,11 +211,9 @@ class QueryParams:
         self._is_erm: bool | None = None
         self._is_cql: bool | None = None
         self._sort_type = _SortType.UNSORTED
-        self._is_default = False
         self._custom_cql = None
 
         if query is None:
-            self._is_default = True
             self._additional_params = httpx.QueryParams()
             return
 
@@ -230,7 +228,6 @@ class QueryParams:
         if is_cql:
             self._is_erm = False
             self._is_cql = True
-            self._is_default = is_default
 
         # Queries and filters could be hiding
         (q, qc, is_cql, is_default) = parser.check_query()
@@ -241,7 +238,6 @@ class QueryParams:
         if is_cql:
             self._is_erm = False
             self._is_cql = True
-            self._is_default = is_default
 
         filters = parser.check_filters()
         if filters is not None:
@@ -364,9 +360,9 @@ class QueryParams:
                 if self._sort_type == _SortType.DESCENDING
                 else f"id>{last_id}"
             )
-            if not self._is_default and self._custom_cql is not None:
+            if self._custom_cql is not None:
                 q += f" and ({self._custom_cql})"
-            elif not self._is_default and len(self._query) == 1:
+            elif len(self._query) == 1:
                 q += f" and ({self._query[0]})"
 
             params = params.set(

--- a/src/httpx_folio/query.py
+++ b/src/httpx_folio/query.py
@@ -291,7 +291,7 @@ class QueryParams:
 
         return params
 
-    def offset_paging(self, page: int | None = None) -> httpx.QueryParams:
+    def offset_paging(self, page: int = 1) -> httpx.QueryParams:
         """Parameters for a single page of results.
 
         Paging by offset has performance issues for large offsets.
@@ -318,7 +318,7 @@ class QueryParams:
             limit = min(limit, ERM_MAX_PERPAGE)
             params = params.set("perPage", limit)
 
-        return params.set("offset", (page or 0) * limit)
+        return params.set("offset", (page - 1) * limit)
 
     def can_page_by_id(self) -> bool:
         """Indicates whether the current set of parameters supports id_paging."""

--- a/src/httpx_folio/query.py
+++ b/src/httpx_folio/query.py
@@ -141,7 +141,7 @@ class QueryParams:
         if self._is_cql is None or self._is_cql:
             params = params.merge(
                 {
-                    # Most endpoints use query,
+                    # CQL endpoints use query,
                     # only some are ok without cql.allRecords but they're all ok with it
                     "query": self._query[0]
                     if len(self._query) == 1

--- a/src/httpx_folio/query.py
+++ b/src/httpx_folio/query.py
@@ -158,6 +158,7 @@ class _QueryParser:
                     return _SortType.ASCENDING
                 if s.lower().strip() == "id;desc":
                     return _SortType.DESCENDING
+                return _SortType.NONSTANDARD
 
         return _SortType.UNSORTED
 
@@ -330,6 +331,13 @@ class QueryParams:
         or for endpoints that do not have an id.
         Use offset_paging instead.
         """
+        if not self.can_page_by_id():
+            msg = (
+                "Id Paging is not supported in the current parameter configuration."
+                "Use Offset Paging instead."
+            )
+            raise RuntimeError(msg)
+
         params = self.normalized()
 
         last_id = last_id or (

--- a/src/httpx_folio/query.py
+++ b/src/httpx_folio/query.py
@@ -39,7 +39,7 @@ class _QueryParser:
         re.IGNORECASE,
     )
     _sort_re = re.compile(
-        r"^.*sortby(?:\s+id(?:(?:(?:\/sort\.)|\s+)?((?:asc)|(?:desc))(?:ending)?)?)?.*$",
+        r"^.*sortby(?:\s+(id)(?:(?:(?:\/sort\.)|\s+)?((?:asc)|(?:desc))(?:ending)?)?)?.*$",
         re.IGNORECASE,
     )
 
@@ -122,8 +122,11 @@ class _QueryParser:
         if not (m := _QueryParser._sort_re.match(q)):
             return _SortType.UNSORTED
 
-        if not (s := m.group(1)):
+        if not m.group(1):
             return _SortType.NONSTANDARD
+
+        if not (s := m.group(2)):
+            return _SortType.ASCENDING
 
         if not isinstance(s, str):
             msg = f"Unexpected value {s} for query parameter."
@@ -315,6 +318,10 @@ class QueryParams:
             params = params.set("perPage", limit)
 
         return params.set("offset", (page or 0) * limit)
+
+    def can_page_by_id(self) -> bool:
+        """Indicates whether the current set of parameters supports id_paging."""
+        return self._sort_type != _SortType.NONSTANDARD
 
     def id_paging(self, last_id: str | None = None) -> httpx.QueryParams:
         """Parameters for a single page of results.

--- a/src/httpx_folio/query.py
+++ b/src/httpx_folio/query.py
@@ -186,3 +186,24 @@ class QueryParams:
                 },
             )
         return params
+
+    def stats(self) -> httpx.QueryParams:
+        """Parameters for a single row to get the shape and totalRecord count.
+
+        Zero or One records will be returned regardless of the endpoint's
+        sorting/filtering practices.
+        """
+        params = self.normalized()
+        # add a sort so null records go to the end
+        if "query" in params and "sortBy" not in params["query"]:
+            params = params.set("query", params["query"] + " sortBy id")
+        if ("sort" not in params) and (self._is_erm is None or self._is_erm):
+            params = params.add("sort", "id;asc")
+
+        # override the limit
+        if "limit" in params:
+            params = params.set("limit", 1)
+        if "perPage" in params:
+            params = params.set("perPage", 1)
+
+        return params

--- a/src/httpx_folio/query.py
+++ b/src/httpx_folio/query.py
@@ -102,7 +102,7 @@ class _QueryParser:
 
         return False
 
-    _reserved = frozenset({"query", "filters", "limit", "perPage", "stats"})
+    _reserved = frozenset({"query", "filters", "limit", "perPage", "offset", "stats"})
 
     def additional_params(self) -> httpx.QueryParams:
         if not isinstance(self.query, (dict, httpx.QueryParams)):
@@ -225,3 +225,14 @@ class QueryParams:
             params = params.set("perPage", 1)
 
         return params
+
+    def offset_paging(self, page: int | None = None) -> httpx.QueryParams:
+        """Parameters for a single page of results."""
+        params = self.normalized()
+        # add a sort so null records go to the end
+        if "query" in params and not self._is_sorted:
+            params = params.set("query", params["query"] + " sortBy id")
+        if ("sort" not in params) and (self._is_erm is None or self._is_erm):
+            params = params.add("sort", "id;asc")
+
+        return params.set("offset", (page or 0) * self._limit)

--- a/src/httpx_folio/query.py
+++ b/src/httpx_folio/query.py
@@ -330,6 +330,7 @@ class QueryParams:
 
         if self._is_erm is None and self._limit > ERM_MAX_PERPAGE:
             # page size can't be normalized if it is over 100
+            params = params.remove("stats")
             params = params.remove("sort")
             params = params.remove("perPage")
 

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -65,7 +65,7 @@ class NormalizedCase:
     expected_limit: str | None = None
     expected_perPage: str | None = None  # noqa: N815
 
-    expected_keys: set[str] = field(default_factory=set)
+    additional_keys: set[str] = field(default_factory=set)
 
 
 class NormalizedCases:
@@ -74,7 +74,7 @@ class NormalizedCases:
             expected_query="cql.allRecords=1",
             expected_limit=str(DEFAULT_PAGE_SIZE),
             expected_perPage=str(DEFAULT_PAGE_SIZE),
-            expected_keys={"stats"},
+            additional_keys={"stats"},
         )
 
     def case_largepage(self) -> NormalizedCase:
@@ -83,7 +83,7 @@ class NormalizedCases:
             expected_query="cql.allRecords=1",
             expected_limit="10000",
             expected_perPage="10000",
-            expected_keys={"stats"},
+            additional_keys={"stats"},
         )
 
     def case_simple_query(self) -> NormalizedCase:
@@ -93,7 +93,7 @@ class NormalizedCases:
             expected_filters="simple query",
             expected_limit=str(DEFAULT_PAGE_SIZE),
             expected_perPage=str(DEFAULT_PAGE_SIZE),
-            expected_keys={"stats"},
+            additional_keys={"stats"},
         )
 
     def case_cql(self) -> NormalizedCase:
@@ -112,17 +112,18 @@ def test_normalized(tc: NormalizedCase) -> None:
         uut(tc.query) if tc.limit is None else uut(tc.query, tc.limit)
     ).normalized()
 
+    expected_keys = tc.additional_keys
     if tc.expected_query is not None:
-        tc.expected_keys.add("query")
+        expected_keys.add("query")
         assert actual["query"] == tc.expected_query
     if tc.expected_filters is not None:
-        tc.expected_keys.add("filters")
+        expected_keys.add("filters")
         assert actual["filters"] == tc.expected_filters
     if tc.expected_limit is not None:
-        tc.expected_keys.add("limit")
+        expected_keys.add("limit")
         assert actual["limit"] == tc.expected_limit
     if tc.expected_perPage is not None:
-        tc.expected_keys.add("perPage")
+        expected_keys.add("perPage")
         assert actual["perPage"] == tc.expected_perPage
 
-    assert set(actual.keys()) - set(tc.expected_keys) == set()
+    assert set(actual.keys()) - set(expected_keys) == set()

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from pytest_cases import parametrize_with_cases
+
+
+@dataclass(frozen=True)
+class IntegrationOkTestCase:
+    endpoint: str
+    query: str | None = None
+
+
+class IntegrationOkTestCases:
+    def case_nonerm_noquery(self) -> IntegrationOkTestCase:
+        return IntegrationOkTestCase("/coursereserves/courses")
+
+    def case_erm_noquery(self) -> IntegrationOkTestCase:
+        return IntegrationOkTestCase("/erm/org")
+
+    def case_nonerm_query(self) -> IntegrationOkTestCase:
+        return IntegrationOkTestCase(
+            "/coursereserves/courses",
+            'department.name = "German Studies"',
+        )
+
+    def case_erm_query(self) -> IntegrationOkTestCase:
+        return IntegrationOkTestCase("/erm/org", "name=~A")
+
+
+class TestIntegration:
+    @parametrize_with_cases("tc", cases=IntegrationOkTestCases)
+    def test_ok(self, tc: IntegrationOkTestCase) -> None:
+        from httpx_folio.factories import FolioParams
+        from httpx_folio.factories import (
+            default_client_factory as make_client_factory,
+        )
+        from httpx_folio.query import QueryParams as uut
+
+        with make_client_factory(
+            FolioParams(
+                "https://folio-etesting-snapshot-kong.ci.folio.org",
+                "diku",
+                "diku_admin",
+                "admin",
+            ),
+        )() as client:
+            res = client.get(tc.endpoint, params=uut(tc.query).normalized())
+            res.raise_for_status()
+
+            j = res.json()
+            assert j["totalRecords"] > 1
+            assert len(j[next(iter(j.keys()))])

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -96,6 +96,13 @@ class NormalizedCases:
             expected_keys={"stats"},
         )
 
+    def case_cql(self) -> NormalizedCase:
+        return NormalizedCase(
+            query="simple query sortBy index",
+            expected_query="simple query sortBy index",
+            expected_limit=str(DEFAULT_PAGE_SIZE),
+        )
+
 
 @parametrize_with_cases("tc", cases=NormalizedCases)
 def test_normalized(tc: NormalizedCase) -> None:

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -92,11 +92,25 @@ class NormalizedCases:
             ),
         )
 
-    def case_cql(self) -> NormalizedCase:
+    def case_cql_str(self) -> NormalizedCase:
         return NormalizedCase(
             query="simple query sortBy index",
             expected=httpx.QueryParams(
                 f"query=simple query sortBy index&limit={DEFAULT_PAGE_SIZE}",
+            ),
+        )
+
+    @parametrize(
+        query=[
+            {"query": "simple query"},
+            httpx.QueryParams({"query": "simple query"}),
+        ],
+    )
+    def case_cql_params(self, query: QueryType) -> NormalizedCase:
+        return NormalizedCase(
+            query=query,
+            expected=httpx.QueryParams(
+                f"query=simple query&limit={DEFAULT_PAGE_SIZE}",
             ),
         )
 

--- a/tests/test_query/__init__.py
+++ b/tests/test_query/__init__.py
@@ -1,0 +1,8 @@
+from dataclasses import dataclass
+
+import httpx
+
+
+@dataclass(frozen=True)
+class QueryParamCase:
+    expected: httpx.QueryParams

--- a/tests/test_query/test_id_paging.py
+++ b/tests/test_query/test_id_paging.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, ClassVar
 
 import httpx
+import pytest
 from pytest_cases import parametrize, parametrize_with_cases
 
 from httpx_folio.query import DEFAULT_PAGE_SIZE, QueryType
@@ -182,3 +183,35 @@ def test_id_paging(tc: IdPagingCase) -> None:
 
     nth_page = uut.id_paging(tc.last_id)
     assert nth_page == tc.expected_fifteenth_page
+
+
+@parametrize(
+    query=[
+        "some query sortBy index"
+        "some query sortby index"
+        "some query SORTBY index"
+        "some query sortBy index asc"
+        "some query sortby index asc"
+        "some query SORTBY index asc"
+        "some query sortBy index/sort.ascending"
+        "some query sortby index/sort.ascending"
+        "some query SORTBY index/sort.ascending"
+        "some query sortBy index desc"
+        "some query sortby index desc"
+        "some query SORTBY index desc"
+        "some query sortBy index/sort.descending"
+        "some query sortby index/sort.descending"
+        "some query SORTBY index/sort.descending",
+        {"sort": "index;asc"},
+        {"sort": "index;desc"},
+    ],
+)
+def test_id_paging_not_supported(query: QueryType) -> None:
+    from httpx_folio.query import QueryParams
+
+    uut = QueryParams(query)
+
+    assert not uut.can_page_by_id()
+
+    with pytest.raises(RuntimeError):
+        uut.id_paging()

--- a/tests/test_query/test_id_paging.py
+++ b/tests/test_query/test_id_paging.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import ClassVar, Iterator
+from typing import TYPE_CHECKING, ClassVar
 
 import httpx
 from pytest_cases import parametrize, parametrize_with_cases
@@ -9,6 +9,9 @@ from pytest_cases import parametrize, parametrize_with_cases
 from httpx_folio.query import DEFAULT_PAGE_SIZE, QueryType
 
 from . import QueryParamCase
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 
 @dataclass(frozen=True)
@@ -22,7 +25,7 @@ class IdPagingCase(QueryParamCase):
     highest_id: ClassVar[str] = "99999999-9999-9999-9999-999999999999"
 
 
-def cql_sortbyid_generator() -> Iterator[tuple[QueryType, bool, str]]:
+def cql_sortbyid_generator() -> Iterator[tuple[str | dict[str, str], bool, str]]:
     sorts = ["sortby", "SORTBY", "sortBy"]
     asc = [
         "",

--- a/tests/test_query/test_id_paging.py
+++ b/tests/test_query/test_id_paging.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import ClassVar
+
+import httpx
+from pytest_cases import parametrize_with_cases
+
+from httpx_folio.query import DEFAULT_PAGE_SIZE, QueryType
+
+from . import QueryParamCase
+
+
+@dataclass(frozen=True)
+class IdPagingCase(QueryParamCase):
+    expected_fifteenth_page: httpx.QueryParams
+    query: QueryType | None = None
+    limit: int | None = None
+
+    lowest_id: ClassVar[str] = "00000000-0000-0000-0000-000000000000"
+    last_id: ClassVar[str] = "a88e5d82-96f7-4d9f-b7d6-1504c3b26a3d"
+    highest_id: ClassVar[str] = "99999999-9999-9999-9999-999999999999"
+
+
+class IdPagingCases:
+    def case_default(self) -> IdPagingCase:
+        return IdPagingCase(
+            expected=httpx.QueryParams(
+                f"query=id>{IdPagingCase.lowest_id} sortBy id"
+                f"&limit={DEFAULT_PAGE_SIZE}&perPage={DEFAULT_PAGE_SIZE}"
+                "&stats=true&sort=id;asc"
+                f"&filters=id>{IdPagingCase.lowest_id}",
+            ),
+            expected_fifteenth_page=httpx.QueryParams(
+                f"query=id>{IdPagingCase.last_id} sortBy id"
+                f"&limit={DEFAULT_PAGE_SIZE}&perPage={DEFAULT_PAGE_SIZE}"
+                "&stats=true&sort=id;asc"
+                f"&filters=id>{IdPagingCase.last_id}",
+            ),
+        )
+
+
+@parametrize_with_cases("tc", cases=IdPagingCases)
+def test_stats(tc: IdPagingCase) -> None:
+    from httpx_folio.query import QueryParams as uut
+
+    first_page = (
+        uut(tc.query) if tc.limit is None else uut(tc.query, tc.limit)
+    ).id_paging()
+
+    assert first_page == tc.expected
+
+    nth_page = (
+        uut(tc.query) if tc.limit is None else uut(tc.query, tc.limit)
+    ).id_paging(tc.last_id)
+    assert nth_page == tc.expected_fifteenth_page

--- a/tests/test_query/test_id_paging.py
+++ b/tests/test_query/test_id_paging.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import ClassVar
 
 import httpx
-from pytest_cases import parametrize_with_cases
+from pytest_cases import parametrize, parametrize_with_cases
 
 from httpx_folio.query import DEFAULT_PAGE_SIZE, QueryType
 
@@ -39,9 +39,84 @@ class IdPagingCases:
             ),
         )
 
+    def case_simple_query(self) -> IdPagingCase:
+        return IdPagingCase(
+            query="simple query",
+            expected=httpx.QueryParams(
+                f"query=id>{IdPagingCase.lowest_id} and (simple query) sortBy id"
+                f"&limit={DEFAULT_PAGE_SIZE}&perPage={DEFAULT_PAGE_SIZE}"
+                "&stats=true&sort=id;asc"
+                f"&filters=simple query&filters=id>{IdPagingCase.lowest_id}",
+            ),
+            expected_fifteenth_page=httpx.QueryParams(
+                f"query=id>{IdPagingCase.last_id} and (simple query) sortBy id"
+                f"&limit={DEFAULT_PAGE_SIZE}&perPage={DEFAULT_PAGE_SIZE}"
+                "&stats=true&sort=id;asc"
+                f"&filters=simple query&filters=id>{IdPagingCase.last_id}",
+            ),
+        )
+
+    @parametrize(
+        query=[
+            {"query": "cql.allRecords=1"},
+            "cql.allRecords=1 sortBy id asc",
+            "cql.allRecords=1 sortBy id ASC",
+            "cql.allRecords=1 sortby id asc",
+            "cql.allRecords=1 sortby id ASC",
+            "cql.allRecords=1 SORTBY id asc",
+            "cql.allRecords=1 SORTBY id ASC",
+            "cql.allRecords=1 sortBy id/sort.ascending",
+            "cql.allRecords=1 sortBy id/sort.asc",
+            "cql.allRecords=1 sortby id/sort.ascending",
+            "cql.allRecords=1 sortby id/sort.asc",
+            "cql.allRecords=1 SORTBY id/sort.ascending",
+            "cql.allRecords=1 SORTBY id/sort.ascending",
+        ],
+    )
+    def case_ascending_default_cql(self, query: QueryType) -> IdPagingCase:
+        return IdPagingCase(
+            query=query,
+            expected=httpx.QueryParams(
+                f"query=id>{IdPagingCase.lowest_id} sortBy id"
+                f"&limit={DEFAULT_PAGE_SIZE}",
+            ),
+            expected_fifteenth_page=httpx.QueryParams(
+                f"query=id>{IdPagingCase.last_id} sortBy id&limit={DEFAULT_PAGE_SIZE}",
+            ),
+        )
+
+    @parametrize(
+        query=[
+            "cql.allRecords=1 sortBy id desc",
+            "cql.allRecords=1 sortBy id DESC",
+            "cql.allRecords=1 sortby id desc",
+            "cql.allRecords=1 sortby id DESC",
+            "cql.allRecords=1 SORTBY id desc",
+            "cql.allRecords=1 SORTBY id DESC",
+            "cql.allRecords=1 sortBy id/sort.descending",
+            "cql.allRecords=1 sortBy id/sort.desc",
+            "cql.allRecords=1 sortby id/sort.descending",
+            "cql.allRecords=1 sortby id/sort.desc",
+            "cql.allRecords=1 SORTBY id/sort.descending",
+            "cql.allRecords=1 SORTBY id/sort.descending",
+        ],
+    )
+    def case_descending_default_cql(self, query: str) -> IdPagingCase:
+        return IdPagingCase(
+            query=query,
+            expected=httpx.QueryParams(
+                f"query=id<{IdPagingCase.highest_id} sortBy id/sort.descending"
+                f"&limit={DEFAULT_PAGE_SIZE}",
+            ),
+            expected_fifteenth_page=httpx.QueryParams(
+                f"query=id<{IdPagingCase.last_id} sortBy id/sort.descending"
+                f"&limit={DEFAULT_PAGE_SIZE}",
+            ),
+        )
+
 
 @parametrize_with_cases("tc", cases=IdPagingCases)
-def test_stats(tc: IdPagingCase) -> None:
+def test_id_paging(tc: IdPagingCase) -> None:
     from httpx_folio.query import QueryParams as uut
 
     first_page = (

--- a/tests/test_query/test_id_paging.py
+++ b/tests/test_query/test_id_paging.py
@@ -171,15 +171,14 @@ class IdPagingCases:
 
 @parametrize_with_cases("tc", cases=IdPagingCases)
 def test_id_paging(tc: IdPagingCase) -> None:
-    from httpx_folio.query import QueryParams as uut
+    from httpx_folio.query import QueryParams
 
-    first_page = (
-        uut(tc.query) if tc.limit is None else uut(tc.query, tc.limit)
-    ).id_paging()
+    uut = QueryParams(tc.query) if tc.limit is None else QueryParams(tc.query, tc.limit)
 
+    assert uut.can_page_by_id()
+
+    first_page = uut.id_paging()
     assert first_page == tc.expected
 
-    nth_page = (
-        uut(tc.query) if tc.limit is None else uut(tc.query, tc.limit)
-    ).id_paging(tc.last_id)
+    nth_page = uut.id_paging(tc.last_id)
     assert nth_page == tc.expected_fifteenth_page

--- a/tests/test_query/test_id_paging.py
+++ b/tests/test_query/test_id_paging.py
@@ -58,7 +58,41 @@ class IdPagingCases:
 
     @parametrize(
         query=[
+            "simple query sortBy id asc",
+            "simple query sortBy id ASC",
+            "simple query sortby id asc",
+            "simple query sortby id ASC",
+            "simple query SORTBY id asc",
+            "simple query SORTBY id ASC",
+            "simple query sortBy id/sort.ascending",
+            "simple query sortBy id/sort.asc",
+            "simple query sortby id/sort.ascending",
+            "simple query sortby id/sort.asc",
+            "simple query SORTBY id/sort.ascending",
+            "simple query SORTBY id/sort.ascending",
+        ],
+    )
+    def case_ascending_query_cql(self, query: QueryType) -> IdPagingCase:
+        return IdPagingCase(
+            query=query,
+            expected=httpx.QueryParams(
+                f"query=id>{IdPagingCase.lowest_id} "
+                "and (simple query) sortBy id"
+                f"&limit={DEFAULT_PAGE_SIZE}",
+            ),
+            expected_fifteenth_page=httpx.QueryParams(
+                f"query=id>{IdPagingCase.last_id} "
+                "and (simple query) sortBy id"
+                f"&limit={DEFAULT_PAGE_SIZE}",
+            ),
+        )
+
+    @parametrize(
+        query=[
             {"query": "cql.allRecords=1"},
+            {"query": "cql.allRecords = 1"},
+            "cql.allRecords=1",
+            "cql.allRecords = 1",
             "cql.allRecords=1 sortBy id asc",
             "cql.allRecords=1 sortBy id ASC",
             "cql.allRecords=1 sortby id asc",

--- a/tests/test_query/test_id_paging.py
+++ b/tests/test_query/test_id_paging.py
@@ -58,6 +58,8 @@ class IdPagingCases:
 
     @parametrize(
         query=[
+            {"query": "simple query sortBy id "},
+            {"query": "simple query"},
             "simple query sortBy id asc",
             "simple query sortBy id ASC",
             "simple query sortby id asc",
@@ -72,7 +74,7 @@ class IdPagingCases:
             "simple query SORTBY id/sort.ascending",
         ],
     )
-    def case_ascending_query_cql(self, query: QueryType) -> IdPagingCase:
+    def case_ascending_simple_query_cql(self, query: QueryType) -> IdPagingCase:
         return IdPagingCase(
             query=query,
             expected=httpx.QueryParams(
@@ -83,6 +85,29 @@ class IdPagingCases:
             expected_fifteenth_page=httpx.QueryParams(
                 f"query=id>{IdPagingCase.last_id} "
                 "and (simple query) sortBy id"
+                f"&limit={DEFAULT_PAGE_SIZE}",
+            ),
+        )
+
+    @parametrize(
+        query=[
+            {"query": "cql.allIndexes=fish"},
+            {"query": "cql.allIndexes=fish sortby id"},
+            "cql.allIndexes=fish",
+            "cql.allIndexes=fish sortby id",
+        ],
+    )
+    def case_ascending_cql_query(self, query: QueryType) -> IdPagingCase:
+        return IdPagingCase(
+            query=query,
+            expected=httpx.QueryParams(
+                f"query=id>{IdPagingCase.lowest_id} "
+                "and (cql.allIndexes=fish) sortBy id"
+                f"&limit={DEFAULT_PAGE_SIZE}",
+            ),
+            expected_fifteenth_page=httpx.QueryParams(
+                f"query=id>{IdPagingCase.last_id} "
+                "and (cql.allIndexes=fish) sortBy id"
                 f"&limit={DEFAULT_PAGE_SIZE}",
             ),
         )

--- a/tests/test_query/test_id_paging.py
+++ b/tests/test_query/test_id_paging.py
@@ -187,20 +187,20 @@ def test_id_paging(tc: IdPagingCase) -> None:
 
 @parametrize(
     query=[
-        "some query sortBy index"
-        "some query sortby index"
-        "some query SORTBY index"
-        "some query sortBy index asc"
-        "some query sortby index asc"
-        "some query SORTBY index asc"
-        "some query sortBy index/sort.ascending"
-        "some query sortby index/sort.ascending"
-        "some query SORTBY index/sort.ascending"
-        "some query sortBy index desc"
-        "some query sortby index desc"
-        "some query SORTBY index desc"
-        "some query sortBy index/sort.descending"
-        "some query sortby index/sort.descending"
+        "some query sortBy index",
+        "some query sortby index",
+        "some query SORTBY index",
+        "some query sortBy index asc",
+        "some query sortby index asc",
+        "some query SORTBY index asc",
+        "some query sortBy index/sort.ascending",
+        "some query sortby index/sort.ascending",
+        "some query SORTBY index/sort.ascending",
+        "some query sortBy index desc",
+        "some query sortby index desc",
+        "some query SORTBY index desc",
+        "some query sortBy index/sort.descending",
+        "some query sortby index/sort.descending",
         "some query SORTBY index/sort.descending",
         {"sort": "index;asc"},
         {"sort": "index;desc"},

--- a/tests/test_query/test_integration.py
+++ b/tests/test_query/test_integration.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from pytest_cases import parametrize_with_cases
+
+
+@dataclass(frozen=True)
+class IntegrationOkTestCase:
+    endpoint: str
+    query: str | None = None
+
+
+class IntegrationOkTestCases:
+    def case_nonerm_noquery(self) -> IntegrationOkTestCase:
+        return IntegrationOkTestCase("/coursereserves/courses")
+
+    def case_erm_noquery(self) -> IntegrationOkTestCase:
+        return IntegrationOkTestCase("/erm/org")
+
+    def case_nonerm_query(self) -> IntegrationOkTestCase:
+        return IntegrationOkTestCase(
+            "/coursereserves/courses",
+            'department.name = "German Studies"',
+        )
+
+    def case_erm_query(self) -> IntegrationOkTestCase:
+        return IntegrationOkTestCase("/erm/org", "name=~A")
+
+
+class TestIntegration:
+    @parametrize_with_cases("tc", cases=IntegrationOkTestCases)
+    def test_ok(self, tc: IntegrationOkTestCase) -> None:
+        from httpx_folio.factories import FolioParams
+        from httpx_folio.factories import (
+            default_client_factory as make_client_factory,
+        )
+        from httpx_folio.query import QueryParams as uut
+
+        with make_client_factory(
+            FolioParams(
+                "https://folio-etesting-snapshot-kong.ci.folio.org",
+                "diku",
+                "diku_admin",
+                "admin",
+            ),
+        )() as client:
+            res = client.get(tc.endpoint, params=uut(tc.query).normalized())
+            res.raise_for_status()
+
+            j = res.json()
+            assert j["totalRecords"] > 1
+            assert len(j[next(iter(j.keys()))])

--- a/tests/test_query/test_integration.py
+++ b/tests/test_query/test_integration.py
@@ -51,3 +51,10 @@ class TestIntegration:
             j = res.json()
             assert j["totalRecords"] > 1
             assert len(j[next(iter(j.keys()))])
+
+            res = client.get(tc.endpoint, params=uut(tc.query).stats())
+            res.raise_for_status()
+
+            j = res.json()
+            assert j["totalRecords"] > 1
+            assert len(j[next(iter(j.keys()))])

--- a/tests/test_query/test_integration.py
+++ b/tests/test_query/test_integration.py
@@ -50,11 +50,36 @@ class TestIntegration:
 
             j = res.json()
             assert j["totalRecords"] > 1
-            assert len(j[next(iter(j.keys()))])
 
             res = client.get(tc.endpoint, params=uut(tc.query).stats())
             res.raise_for_status()
 
             j = res.json()
             assert j["totalRecords"] > 1
-            assert len(j[next(iter(j.keys()))])
+            assert len(j[next(iter(j.keys()))]) == 1
+
+            op = uut(tc.query, limit=2)
+            res = client.get(tc.endpoint, params=op.offset_paging())
+            res.raise_for_status()
+            j = res.json()
+            id1 = j[next(iter(j.keys()))][-1]["id"]
+
+            res = client.get(tc.endpoint, params=op.offset_paging(2))
+            res.raise_for_status()
+            j = res.json()
+            id2 = j[next(iter(j.keys()))][0]["id"]
+
+            assert id1 < id2
+
+            ip = uut(tc.query, limit=2)
+            res = client.get(tc.endpoint, params=ip.id_paging())
+            res.raise_for_status()
+            j = res.json()
+            id1 = j[next(iter(j.keys()))][-1]["id"]
+
+            res = client.get(tc.endpoint, params=ip.id_paging(last_id=id1))
+            res.raise_for_status()
+            j = res.json()
+            id2 = j[next(iter(j.keys()))][0]["id"]
+
+            assert id1 < id2

--- a/tests/test_query/test_normalized.py
+++ b/tests/test_query/test_normalized.py
@@ -7,59 +7,11 @@ from pytest_cases import parametrize, parametrize_with_cases
 
 from httpx_folio.query import DEFAULT_PAGE_SIZE, QueryType
 
-
-@dataclass(frozen=True)
-class IntegrationOkTestCase:
-    endpoint: str
-    query: str | None = None
-
-
-class IntegrationOkTestCases:
-    def case_nonerm_noquery(self) -> IntegrationOkTestCase:
-        return IntegrationOkTestCase("/coursereserves/courses")
-
-    def case_erm_noquery(self) -> IntegrationOkTestCase:
-        return IntegrationOkTestCase("/erm/org")
-
-    def case_nonerm_query(self) -> IntegrationOkTestCase:
-        return IntegrationOkTestCase(
-            "/coursereserves/courses",
-            'department.name = "German Studies"',
-        )
-
-    def case_erm_query(self) -> IntegrationOkTestCase:
-        return IntegrationOkTestCase("/erm/org", "name=~A")
-
-
-class TestIntegration:
-    @parametrize_with_cases("tc", cases=IntegrationOkTestCases)
-    def test_ok(self, tc: IntegrationOkTestCase) -> None:
-        from httpx_folio.factories import FolioParams
-        from httpx_folio.factories import (
-            default_client_factory as make_client_factory,
-        )
-        from httpx_folio.query import QueryParams as uut
-
-        with make_client_factory(
-            FolioParams(
-                "https://folio-etesting-snapshot-kong.ci.folio.org",
-                "diku",
-                "diku_admin",
-                "admin",
-            ),
-        )() as client:
-            res = client.get(tc.endpoint, params=uut(tc.query).normalized())
-            res.raise_for_status()
-
-            j = res.json()
-            assert j["totalRecords"] > 1
-            assert len(j[next(iter(j.keys()))])
+from . import QueryParamCase
 
 
 @dataclass(frozen=True)
-class NormalizedCase:
-    expected: httpx.QueryParams
-
+class NormalizedCase(QueryParamCase):
     query: QueryType | None = None
     limit: int | None = None
 

--- a/tests/test_query/test_normalized.py
+++ b/tests/test_query/test_normalized.py
@@ -26,6 +26,17 @@ class NormalizedCases:
             ),
         )
 
+    def case_additional_params(self) -> NormalizedCase:
+        return NormalizedCase(
+            query={"additional": "param1", "and": "param2"},
+            expected=httpx.QueryParams(
+                "query=cql.allRecords=1"
+                "&additional=param1&and=param2"
+                f"&limit={DEFAULT_PAGE_SIZE}&perPage={DEFAULT_PAGE_SIZE}"
+                "&stats=true",
+            ),
+        )
+
     def case_largepage(self) -> NormalizedCase:
         return NormalizedCase(
             limit=10000,
@@ -63,6 +74,23 @@ class NormalizedCases:
             query=query,
             expected=httpx.QueryParams(
                 f"query=simple query&limit={DEFAULT_PAGE_SIZE}",
+            ),
+        )
+
+    @parametrize(
+        query=[
+            {"sort": "id;asc"},
+            httpx.QueryParams({"sort": "id;asc"}),
+        ],
+    )
+    def case_erm_params(
+        self,
+        query: QueryType,
+    ) -> NormalizedCase:
+        return NormalizedCase(
+            query=query,
+            expected=httpx.QueryParams(
+                f"sort=id;asc&perPage={DEFAULT_PAGE_SIZE}&stats=true",
             ),
         )
 

--- a/tests/test_query/test_normalized.py
+++ b/tests/test_query/test_normalized.py
@@ -55,11 +55,18 @@ class NormalizedCases:
             ),
         )
 
-    def case_cql_str(self) -> NormalizedCase:
+    @parametrize(
+        query=[
+            "simple query sortby index",
+            "simple query sortBy index",
+            "simple query SORTBY index",
+        ],
+    )
+    def case_cql_str(self, query: str) -> NormalizedCase:
         return NormalizedCase(
-            query="simple query sortBy index",
+            query=query,
             expected=httpx.QueryParams(
-                f"query=simple query sortBy index&limit={DEFAULT_PAGE_SIZE}",
+                f"query={query}&limit={DEFAULT_PAGE_SIZE}",
             ),
         )
 

--- a/tests/test_query/test_offset_paging.py
+++ b/tests/test_query/test_offset_paging.py
@@ -18,7 +18,7 @@ class OffsetPagingCase(QueryParamCase):
 
 
 class OffsetPagingCases:
-    def case_default(self) -> OffsetPagingCase:
+    def case_indeterminate_default(self) -> OffsetPagingCase:
         return OffsetPagingCase(
             expected=httpx.QueryParams(
                 "query=cql.allRecords=1 sortBy id"
@@ -32,7 +32,7 @@ class OffsetPagingCases:
             ),
         )
 
-    def case_simple_query(self) -> OffsetPagingCase:
+    def case_indeterminate_simple_query(self) -> OffsetPagingCase:
         return OffsetPagingCase(
             query="simple query",
             expected=httpx.QueryParams(
@@ -47,59 +47,79 @@ class OffsetPagingCases:
             ),
         )
 
-    def case_bigger_page_default(self) -> OffsetPagingCase:
+    def case_indeterminate_bigger_page(self) -> OffsetPagingCase:
         return OffsetPagingCase(
             limit=1000,
             expected=httpx.QueryParams(
-                "query=cql.allRecords=1 sortBy id&limit=1000&stats=true&offset=0",
+                "query=cql.allRecords=1 sortBy id&limit=1000&offset=0",
             ),
             expected_fifteenth_page=httpx.QueryParams(
-                "query=cql.allRecords=1 sortBy id&limit=1000&stats=true&offset=15000",
+                "query=cql.allRecords=1 sortBy id&limit=1000&offset=15000",
             ),
         )
 
-    def case_smaller_page_default(self) -> OffsetPagingCase:
+    def case_indeterminate_smaller_page(self) -> OffsetPagingCase:
         return OffsetPagingCase(
             limit=50,
             expected=httpx.QueryParams(
-                "query=cql.allRecords=1 sortBy id"
-                "&limit=50&perPage=50"
-                "&stats=true&sort=id;asc&offset=0",
+                "query=cql.allRecords=1 sortBy id&limit=50"
+                "&perPage=50&stats=true&sort=id;asc"
+                "&offset=0",
             ),
             expected_fifteenth_page=httpx.QueryParams(
-                "query=cql.allRecords=1 sortBy id"
-                "&limit=50&perPage=50"
-                "&stats=true&sort=id;asc&offset=750",
+                "query=cql.allRecords=1 sortBy id&limit=50"
+                "&perPage=50&stats=true&sort=id;asc"
+                "&offset=750",
             ),
         )
 
-    def case_cql_unsorted(self) -> OffsetPagingCase:
+    @parametrize(
+        query=[
+            {"query": "some query"},
+            "cql.allRecords=1",
+            "cql.allIndices=fish",
+        ],
+    )
+    def case_cql_unsorted(self, query: QueryType) -> OffsetPagingCase:
+        expected = query["query"] if isinstance(query, dict) else query
         return OffsetPagingCase(
-            query={"query": "simple query"},
+            query=query,
             expected=httpx.QueryParams(
-                f"query=simple query sortBy id&limit={DEFAULT_PAGE_SIZE}&offset=0",
+                f"query={expected} sortBy id&limit={DEFAULT_PAGE_SIZE}&offset=0",
             ),
             expected_fifteenth_page=httpx.QueryParams(
-                "query=simple query sortBy id"
+                f"query={expected} sortBy id"
                 f"&limit={DEFAULT_PAGE_SIZE}&offset={DEFAULT_PAGE_SIZE * 15}",
             ),
         )
 
     @parametrize(
         query=[
-            "simple query sortby index",
-            "simple query sortBy index",
-            "simple query SORTBY index",
+            {"query": "some query sortBy index"},
+            {"query": "some query SORTBY index"},
+            {"query": "some query sortby index"},
+            {"query": "some query sortby index asc"},
+            {"query": "some query sortby index desc"},
+            {"query": "some query sortby index/sort.asc"},
+            {"query": "some query sortby index/sort.desc"},
+            "cql.allRecords=1 sortBy index",
+            "cql.allIndices=fish SORTBY index",
+            "cql.allRecords=1 sortby index",
+            "cql.allIndices=fish sortby index asc",
+            "cql.allRecords=1 sortby index desc",
+            "cql.allIndices=fish sortby index/sort.asc",
+            "cql.allRecords=1 sortby index/sort.desc",
         ],
     )
-    def case_cql_sorted(self, query: str) -> OffsetPagingCase:
+    def case_cql_sorted(self, query: QueryType) -> OffsetPagingCase:
+        expected = query["query"] if isinstance(query, dict) else query
         return OffsetPagingCase(
             query=query,
             expected=httpx.QueryParams(
-                f"query={query}&limit={DEFAULT_PAGE_SIZE}&offset=0",
+                f"query={expected}&limit={DEFAULT_PAGE_SIZE}&offset=0",
             ),
             expected_fifteenth_page=httpx.QueryParams(
-                f"query={query}"
+                f"query={expected}"
                 f"&limit={DEFAULT_PAGE_SIZE}&offset={DEFAULT_PAGE_SIZE * 15}",
             ),
         )

--- a/tests/test_query/test_offset_paging.py
+++ b/tests/test_query/test_offset_paging.py
@@ -28,7 +28,7 @@ class OffsetPagingCases:
             expected_fifteenth_page=httpx.QueryParams(
                 "query=cql.allRecords=1 sortBy id"
                 f"&limit={DEFAULT_PAGE_SIZE}&perPage={DEFAULT_PAGE_SIZE}"
-                f"&stats=true&sort=id;asc&offset={DEFAULT_PAGE_SIZE * 15}",
+                f"&stats=true&sort=id;asc&offset={DEFAULT_PAGE_SIZE * 14}",
             ),
         )
 
@@ -43,7 +43,7 @@ class OffsetPagingCases:
             expected_fifteenth_page=httpx.QueryParams(
                 "query=simple query sortBy id&filters=simple query"
                 f"&limit={DEFAULT_PAGE_SIZE}&perPage={DEFAULT_PAGE_SIZE}"
-                f"&stats=true&sort=id;asc&offset={DEFAULT_PAGE_SIZE * 15}",
+                f"&stats=true&sort=id;asc&offset={DEFAULT_PAGE_SIZE * 14}",
             ),
         )
 
@@ -54,7 +54,7 @@ class OffsetPagingCases:
                 "query=cql.allRecords=1 sortBy id&limit=1000&offset=0",
             ),
             expected_fifteenth_page=httpx.QueryParams(
-                "query=cql.allRecords=1 sortBy id&limit=1000&offset=15000",
+                "query=cql.allRecords=1 sortBy id&limit=1000&offset=14000",
             ),
         )
 
@@ -69,7 +69,7 @@ class OffsetPagingCases:
             expected_fifteenth_page=httpx.QueryParams(
                 "query=cql.allRecords=1 sortBy id&limit=50"
                 "&perPage=50&stats=true&sort=id;asc"
-                "&offset=750",
+                "&offset=700",
             ),
         )
 
@@ -89,7 +89,7 @@ class OffsetPagingCases:
             ),
             expected_fifteenth_page=httpx.QueryParams(
                 f"query={expected} sortBy id"
-                f"&limit={DEFAULT_PAGE_SIZE}&offset={DEFAULT_PAGE_SIZE * 15}",
+                f"&limit={DEFAULT_PAGE_SIZE}&offset={DEFAULT_PAGE_SIZE * 14}",
             ),
         )
 
@@ -120,7 +120,7 @@ class OffsetPagingCases:
             ),
             expected_fifteenth_page=httpx.QueryParams(
                 f"query={expected}"
-                f"&limit={DEFAULT_PAGE_SIZE}&offset={DEFAULT_PAGE_SIZE * 15}",
+                f"&limit={DEFAULT_PAGE_SIZE}&offset={DEFAULT_PAGE_SIZE * 14}",
             ),
         )
 
@@ -136,7 +136,7 @@ class OffsetPagingCases:
                 "filters=simple query"
                 f"&perPage={DEFAULT_PAGE_SIZE}"
                 "&stats=true&sort=id;asc"
-                f"&offset={DEFAULT_PAGE_SIZE * 15}",
+                f"&offset={DEFAULT_PAGE_SIZE * 14}",
             ),
         )
 
@@ -152,7 +152,7 @@ class OffsetPagingCases:
                 "filters=simple query"
                 f"&perPage={DEFAULT_PAGE_SIZE}"
                 "&stats=true&sort=index;desc"
-                f"&offset={DEFAULT_PAGE_SIZE * 15}",
+                f"&offset={DEFAULT_PAGE_SIZE * 14}",
             ),
         )
 
@@ -169,7 +169,7 @@ class OffsetPagingCases:
                 "filters=simple query"
                 f"&perPage={ERM_MAX_PERPAGE}"
                 "&stats=true&sort=id;asc"
-                f"&offset={ERM_MAX_PERPAGE * 15}",
+                f"&offset={ERM_MAX_PERPAGE * 14}",
             ),
         )
 

--- a/tests/test_query/test_offset_paging.py
+++ b/tests/test_query/test_offset_paging.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import httpx
+from pytest_cases import parametrize_with_cases
+
+from httpx_folio.query import DEFAULT_PAGE_SIZE, QueryType
+
+
+@dataclass(frozen=True)
+class OffsetPagingCase:
+    expected_first_page: httpx.QueryParams
+    expected_fifteenth_page: httpx.QueryParams
+    query: QueryType | None = None
+    limit: int | None = None
+
+
+class OffsetPagingCases:
+    def case_default(self) -> OffsetPagingCase:
+        return OffsetPagingCase(
+            expected_first_page=httpx.QueryParams(
+                "query=cql.allRecords=1 sortBy id"
+                f"&limit={DEFAULT_PAGE_SIZE}&perPage={DEFAULT_PAGE_SIZE}"
+                "&stats=true&sort=id;asc&offset=0",
+            ),
+            expected_fifteenth_page=httpx.QueryParams(
+                "query=cql.allRecords=1 sortBy id"
+                f"&limit={DEFAULT_PAGE_SIZE}&perPage={DEFAULT_PAGE_SIZE}"
+                f"&stats=true&sort=id;asc&offset={DEFAULT_PAGE_SIZE * 15}",
+            ),
+        )
+
+
+@parametrize_with_cases("tc", cases=OffsetPagingCases)
+def test_stats(tc: OffsetPagingCase) -> None:
+    from httpx_folio.query import QueryParams as uut
+
+    first_page = (
+        uut(tc.query) if tc.limit is None else uut(tc.query, tc.limit)
+    ).offset_paging()
+
+    assert first_page == tc.expected_first_page
+
+    nth_page = (
+        uut(tc.query) if tc.limit is None else uut(tc.query, tc.limit)
+    ).offset_paging(page=15)
+    assert nth_page == tc.expected_fifteenth_page

--- a/tests/test_query/test_offset_paging.py
+++ b/tests/test_query/test_offset_paging.py
@@ -155,7 +155,7 @@ class OffsetPagingCases:
 
 
 @parametrize_with_cases("tc", cases=OffsetPagingCases)
-def test_stats(tc: OffsetPagingCase) -> None:
+def test_offset_paging(tc: OffsetPagingCase) -> None:
     from httpx_folio.query import QueryParams as uut
 
     first_page = (

--- a/tests/test_query/test_offset_paging.py
+++ b/tests/test_query/test_offset_paging.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 import httpx
 from pytest_cases import parametrize, parametrize_with_cases
 
-from httpx_folio.query import DEFAULT_PAGE_SIZE, QueryType
+from httpx_folio.query import DEFAULT_PAGE_SIZE, ERM_MAX_PERPAGE, QueryType
 
 from . import QueryParamCase
 
@@ -104,8 +104,54 @@ class OffsetPagingCases:
             ),
         )
 
-    # cql, sortiness
-    # erm, sortiness & hard limit
+    def case_erm_unsorted(self) -> OffsetPagingCase:
+        return OffsetPagingCase(
+            query={"filters": "simple query"},
+            expected=httpx.QueryParams(
+                "filters=simple query"
+                f"&perPage={DEFAULT_PAGE_SIZE}"
+                "&stats=true&sort=id;asc&offset=0",
+            ),
+            expected_fifteenth_page=httpx.QueryParams(
+                "filters=simple query"
+                f"&perPage={DEFAULT_PAGE_SIZE}"
+                "&stats=true&sort=id;asc"
+                f"&offset={DEFAULT_PAGE_SIZE * 15}",
+            ),
+        )
+
+    def case_erm_sorted(self) -> OffsetPagingCase:
+        return OffsetPagingCase(
+            query={"filters": "simple query", "sort": "index;desc"},
+            expected=httpx.QueryParams(
+                "filters=simple query"
+                f"&perPage={DEFAULT_PAGE_SIZE}"
+                "&stats=true&sort=index;desc&offset=0",
+            ),
+            expected_fifteenth_page=httpx.QueryParams(
+                "filters=simple query"
+                f"&perPage={DEFAULT_PAGE_SIZE}"
+                "&stats=true&sort=index;desc"
+                f"&offset={DEFAULT_PAGE_SIZE * 15}",
+            ),
+        )
+
+    def case_erm_hardlimit(self) -> OffsetPagingCase:
+        return OffsetPagingCase(
+            query={"filters": "simple query"},
+            limit=1000,
+            expected=httpx.QueryParams(
+                "filters=simple query"
+                f"&perPage={ERM_MAX_PERPAGE}"
+                "&stats=true&sort=id;asc&offset=0",
+            ),
+            expected_fifteenth_page=httpx.QueryParams(
+                "filters=simple query"
+                f"&perPage={ERM_MAX_PERPAGE}"
+                "&stats=true&sort=id;asc"
+                f"&offset={ERM_MAX_PERPAGE * 15}",
+            ),
+        )
 
 
 @parametrize_with_cases("tc", cases=OffsetPagingCases)

--- a/tests/test_query/test_stats.py
+++ b/tests/test_query/test_stats.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 import httpx
-from pytest_cases import parametrize_with_cases
+from pytest_cases import parametrize, parametrize_with_cases
 
 from . import QueryParamCase
 
@@ -27,9 +27,73 @@ class StatsCases:
             ),
         )
 
+    @parametrize(
+        query=[
+            "simple query sortby index",
+            "simple query sortBy index",
+            "simple query SORTBY index",
+        ],
+    )
+    def case_sorted_cql(self, query: str) -> StatsCase:
+        return StatsCase(
+            query=query,
+            expected=httpx.QueryParams(
+                f"query={query}&limit=1",
+            ),
+        )
+
+    @parametrize(
+        query=[
+            "simple query sortby index",
+            "simple query sortBy index",
+            "simple query SORTBY index",
+        ],
+    )
+    def case_sorted_cql_dict(self, query: str) -> StatsCase:
+        return StatsCase(
+            query={"query": query},
+            expected=httpx.QueryParams(
+                f"query={query}&limit=1",
+            ),
+        )
+
+    def case_add_sort_cql(self) -> StatsCase:
+        return StatsCase(
+            query={"query": "simple query"},
+            expected=httpx.QueryParams(
+                "query=simple query sortBy id&limit=1",
+            ),
+        )
+
+    def case_add_sort(self) -> StatsCase:
+        return StatsCase(
+            query="simple query",
+            expected=httpx.QueryParams(
+                "query=simple query sortBy id&filters=simple query"
+                "&sort=id;asc&limit=1&perPage=1"
+                "&stats=true",
+            ),
+        )
+
+    def case_add_sort_erm(self) -> StatsCase:
+        return StatsCase(
+            query={"filters": "simple query"},
+            expected=httpx.QueryParams(
+                "filters=simple query&sort=id;asc&perPage=1&stats=true",
+            ),
+        )
+
+    def case_sorted_erm(self) -> StatsCase:
+        return StatsCase(
+            query={"filters": "simple query", "sort": "index;desc"},
+            expected=httpx.QueryParams(
+                "filters=simple query&sort=index;desc&perPage=1&stats=true",
+            ),
+        )
+
 
 @parametrize_with_cases("tc", cases=StatsCases)
-def test_normalized(tc: StatsCase) -> None:
+def test_stats(tc: StatsCase) -> None:
     from httpx_folio.query import QueryParams as uut
 
     actual = uut(tc.query, 1000).stats()

--- a/tests/test_query/test_stats.py
+++ b/tests/test_query/test_stats.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import httpx
+from pytest_cases import parametrize_with_cases
+
+from . import QueryParamCase
+
+if TYPE_CHECKING:
+    from httpx_folio.query import QueryType
+
+
+@dataclass(frozen=True)
+class StatsCase(QueryParamCase):
+    query: QueryType | None = None
+
+
+class StatsCases:
+    def case_default(self) -> StatsCase:
+        return StatsCase(
+            expected=httpx.QueryParams(
+                "query=cql.allRecords=1 sortBy id"
+                "&sort=id;asc&limit=1&perPage=1"
+                "&stats=true",
+            ),
+        )
+
+
+@parametrize_with_cases("tc", cases=StatsCases)
+def test_normalized(tc: StatsCase) -> None:
+    from httpx_folio.query import QueryParams as uut
+
+    actual = uut(tc.query, 1000).stats()
+    assert actual == tc.expected


### PR DESCRIPTION
FOLIO endpoints are fairly consistent in their handling of query and sort, relying on CQL. ERM endpoints follow different rules. LDLite (and really any folio client) usually relies on having one parameter for queries. This is mostly fine if we weren't also trying to do some magic manipulations of limits, offsets, and ids to page or get single records.  I've pulled out the normalization logic from LDLite and expanded upon it with many many tests and a couple of bug fixes here. It's complicated but FOLIO is complicated.