### PR TITLE
Optionally use path to determine if query can page by id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ Please see [MIGRATING.md](./MIGRATING.md) for information on breaking changes.
 
 ### Removed
 
+## [0.3.0] - November 2025
+
+### Added
+- Additional path parameter to determine whether an endpoint supports id paging
+
 ## [0.2.3] - September 2025
 
 ### Fixed

--- a/src/httpx_folio/query.py
+++ b/src/httpx_folio/query.py
@@ -187,9 +187,22 @@ class QueryParams:
 
         return params.set("offset", (page - 1) * limit)
 
-    def can_page_by_id(self) -> bool:
-        """Indicates whether the current set of parameters supports id_paging."""
-        return self._sort_type != _SortType.NONSTANDARD
+    _NONSTANDARD_PAGING = frozenset(
+        {
+            "/calendar/calendars",
+        },
+    )
+
+    def can_page_by_id(self, path: str | None = None) -> bool:
+        """Indicates whether the current set of parameters supports id_paging.
+
+        There are some endpoints in FOLIO that are known to not support id paging.
+        These endpoints either succeed with incorrect results or infinitely page.
+        You can pass the path you intend to page to check against the known list.
+        """
+        return (
+            path is None or path not in self._NONSTANDARD_PAGING
+        ) and self._sort_type != _SortType.NONSTANDARD
 
     def id_paging(self, *, last_id: str | None = None) -> httpx.QueryParams:
         """Parameters for a single page of results.

--- a/tests/test_query/test_id_paging.py
+++ b/tests/test_query/test_id_paging.py
@@ -215,3 +215,16 @@ def test_id_paging_not_supported(query: QueryType) -> None:
 
     with pytest.raises(RuntimeError):
         uut.id_paging()
+
+
+@parametrize(
+    path=[
+        "/calendar/calendars",
+    ],
+)
+def test_id_paging_not_recommended(path: str) -> None:
+    from httpx_folio.query import QueryParams
+
+    uut = QueryParams(None)
+
+    assert not uut.can_page_by_id(path)

--- a/tests/test_query/test_integration.py
+++ b/tests/test_query/test_integration.py
@@ -9,6 +9,7 @@ from pytest_cases import parametrize_with_cases
 class IntegrationOkTestCase:
     endpoint: str
     query: str | None = None
+    comp: str = "id"
 
 
 class IntegrationOkTestCases:
@@ -21,11 +22,17 @@ class IntegrationOkTestCases:
     def case_nonerm_query(self) -> IntegrationOkTestCase:
         return IntegrationOkTestCase(
             "/coursereserves/courses",
-            'department.name = "German Studies"',
+            query='department.name = "German Studies"',
         )
 
     def case_erm_query(self) -> IntegrationOkTestCase:
-        return IntegrationOkTestCase("/erm/org", "name=~A")
+        return IntegrationOkTestCase("/erm/org", query="name=~A")
+
+    def case_calendars(self) -> IntegrationOkTestCase:
+        return IntegrationOkTestCase(
+            "/calendar/calendars",
+            comp="startDate",
+        )
 
 
 class TestIntegration:
@@ -62,24 +69,25 @@ class TestIntegration:
             res = client.get(tc.endpoint, params=op.offset_paging())
             res.raise_for_status()
             j = res.json()
-            id1 = j[next(iter(j.keys()))][-1]["id"]
+            comp1 = j[next(iter(j.keys()))][-1][tc.comp]
 
             res = client.get(tc.endpoint, params=op.offset_paging(page=2))
             res.raise_for_status()
             j = res.json()
-            id2 = j[next(iter(j.keys()))][0]["id"]
+            comp2 = j[next(iter(j.keys()))][0][tc.comp]
 
-            assert id1 < id2
+            assert comp1 < comp2
 
             ip = uut(tc.query, limit=2)
-            res = client.get(tc.endpoint, params=ip.id_paging())
-            res.raise_for_status()
-            j = res.json()
-            id1 = j[next(iter(j.keys()))][-1]["id"]
+            if ip.can_page_by_id(path=tc.endpoint):
+                res = client.get(tc.endpoint, params=ip.id_paging())
+                res.raise_for_status()
+                j = res.json()
+                comp1 = j[next(iter(j.keys()))][-1][tc.comp]
 
-            res = client.get(tc.endpoint, params=ip.id_paging(last_id=id1))
-            res.raise_for_status()
-            j = res.json()
-            id2 = j[next(iter(j.keys()))][0]["id"]
+                res = client.get(tc.endpoint, params=ip.id_paging(last_id=comp1))
+                res.raise_for_status()
+                j = res.json()
+                comp2 = j[next(iter(j.keys()))][0][tc.comp]
 
-            assert id1 < id2
+                assert comp1 < comp2


### PR DESCRIPTION
At least one endpoint has nonstandard behavior as far as sorting and queries go. It currently infinitely loops if paged by id but can be paged by offset. This adds the ability to check for the endpoint (and any others that are found in the future).